### PR TITLE
updated practitioner schema

### DIFF
--- a/apispec/schema.yml
+++ b/apispec/schema.yml
@@ -250,8 +250,6 @@ paths:
                   format: email
                 telephone_number:
                   type: string
-                ip_code:
-                  type: string
                 appointed_on:
                   type: string
                   format: date
@@ -561,7 +559,11 @@ components:
     PractitionerWritable:
       type: object
       properties:
-        name:
+        first_name:
+          type: string
+        last_name:
+          type: string
+        ip_code:
           type: string
         address:
           type: object
@@ -586,7 +588,9 @@ components:
           format: date
         ip_code:
           type: string
-        name:
+        first_name:
+          type: string
+        last_name:
           type: string
         address:
           type: object


### PR DESCRIPTION
Updated practitioners resource to include first name, last name and ip code. Can be viewed here https://editor.swagger.io/?url=https://raw.githubusercontent.com/companieshouse/insolvency-api/spec-update/apispec/schema.yml