### PR TITLE
Patch transaction API with insolvency resource

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,11 +4,11 @@ go 1.12
 
 require (
 	github.com/companieshouse/api-sdk-go v0.1.12
-	github.com/companieshouse/chs.go v1.2.1
+	github.com/companieshouse/chs.go v1.2.2
 	github.com/companieshouse/go-sdk-manager v0.1.6
 	github.com/companieshouse/go-session-handler v0.1.5
 	github.com/companieshouse/gofigure v0.1.4
-	github.com/companieshouse/private-api-sdk-go v0.1.1
+	github.com/companieshouse/private-api-sdk-go v0.1.7
 	github.com/go-playground/validator/v10 v10.4.1
 	github.com/golang/mock v1.5.0
 	github.com/gorilla/mux v1.7.3

--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,12 @@ module github.com/companieshouse/insolvency-api
 go 1.12
 
 require (
-	github.com/companieshouse/api-sdk-go v0.1.0
+	github.com/companieshouse/api-sdk-go v0.1.12
 	github.com/companieshouse/chs.go v1.2.1
 	github.com/companieshouse/go-sdk-manager v0.1.6
 	github.com/companieshouse/go-session-handler v0.1.5
 	github.com/companieshouse/gofigure v0.1.4
+	github.com/companieshouse/private-api-sdk-go v0.1.1
 	github.com/go-playground/validator/v10 v10.4.1
 	github.com/golang/mock v1.5.0
 	github.com/gorilla/mux v1.7.3

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/aws/aws-sdk-go v1.34.28 h1:sscPpn/Ns3i0F4HPEWAVcwdIRaZZCuL7llJ2/60yPI
 github.com/aws/aws-sdk-go v1.34.28/go.mod h1:H7NKnBqNVzoTJpGfLrQkkD+ytBA93eiDYi/+8rV9s48=
 github.com/companieshouse/api-sdk-go v0.1.0 h1:VBOqkeb50riSyRmoKF9rqvkFJ7El3aS0qT6p8y9z8Ho=
 github.com/companieshouse/api-sdk-go v0.1.0/go.mod h1:lf4uNUbwgU0FyJvoAToNAwNwN9GW2w6Vlpw3KGPtAeQ=
+github.com/companieshouse/api-sdk-go v0.1.12 h1:S28W98tq3MW1hoKVe8eb4zYtpmmG0lST9HRrn9z3lTg=
+github.com/companieshouse/api-sdk-go v0.1.12/go.mod h1:y7Mly0M9Jfgq/hhlWNodyWI9FcpoMZUVClS+AyaT6xY=
 github.com/companieshouse/chs.go v1.1.0/go.mod h1:LVtty6/5ttvNf12V/nPySaIFgfYPLeT0jymabuzmSDg=
 github.com/companieshouse/chs.go v1.2.1 h1:DS7SJfoFqTzmL2mQo4a8KK8GdFQnRtMJOJ+47STUHqI=
 github.com/companieshouse/chs.go v1.2.1/go.mod h1:93vQ2qlzSbZenUOFet+pAJzxHdz+w6BF1IvJ56lvC7c=
@@ -195,6 +197,7 @@ golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20191112182307-2180aed22343/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2 h1:CCH4IOTTfewWjGOlSp+zGcjutRKlBEZQ6wTn8ozI/nI=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45 h1:SVwTIAaPC2U/AvvLNZ2a7OVsmBpC8L5BlwK1whH3hm0=

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/companieshouse/api-sdk-go v0.1.0/go.mod h1:lf4uNUbwgU0FyJvoAToNAwNwN9
 github.com/companieshouse/api-sdk-go v0.1.12 h1:S28W98tq3MW1hoKVe8eb4zYtpmmG0lST9HRrn9z3lTg=
 github.com/companieshouse/api-sdk-go v0.1.12/go.mod h1:y7Mly0M9Jfgq/hhlWNodyWI9FcpoMZUVClS+AyaT6xY=
 github.com/companieshouse/chs.go v1.1.0/go.mod h1:LVtty6/5ttvNf12V/nPySaIFgfYPLeT0jymabuzmSDg=
-github.com/companieshouse/chs.go v1.2.1 h1:DS7SJfoFqTzmL2mQo4a8KK8GdFQnRtMJOJ+47STUHqI=
-github.com/companieshouse/chs.go v1.2.1/go.mod h1:93vQ2qlzSbZenUOFet+pAJzxHdz+w6BF1IvJ56lvC7c=
+github.com/companieshouse/chs.go v1.2.2 h1:ltbQj2i3EkrF+zkilS0w94Z2hTLeN3OaqHu1/djGJVo=
+github.com/companieshouse/chs.go v1.2.2/go.mod h1:93vQ2qlzSbZenUOFet+pAJzxHdz+w6BF1IvJ56lvC7c=
 github.com/companieshouse/envconf v0.1.0 h1:6EAyUYqBJsduWZQuz1AR8hxG5OwhPK0r3Y6ppcTDBmQ=
 github.com/companieshouse/envconf v0.1.0/go.mod h1:/gP4p46vTAENnqc2vXW441VOjL91ReJv/uqnYBzlaFo=
 github.com/companieshouse/go-sdk-manager v0.1.6 h1:hSq6o7w3cOMqkP9MP+utkRoHftylz8a+I/LoPctaFmM=
@@ -23,8 +23,9 @@ github.com/companieshouse/gofigure v0.1.0/go.mod h1:W7NZ4kQdDXqvqK1f7EKTc+pnnqpF
 github.com/companieshouse/gofigure v0.1.4 h1:BN7Dqn0xvNHwC+KHOUHigwP7ajkfHORos3hKRtEACUU=
 github.com/companieshouse/gofigure v0.1.4/go.mod h1:lBAsI13q21rMce+pO7x4xUYAXzO0MchuDsZUbCs0Yng=
 github.com/companieshouse/htmlform v0.1.0/go.mod h1:fWScPVYjGyeBhYwppGaGRDtCQ5hMd3t3Q+0I6HaUZT4=
-github.com/companieshouse/private-api-sdk-go v0.1.1 h1:scnN84r25F9NJHfz2XbSfIgUAm2x+l1JhHaWhhcUcUE=
 github.com/companieshouse/private-api-sdk-go v0.1.1/go.mod h1:e2gCeSswJosqHMbfNmx6tJ7GpyFy8iDjOYeFWVSNQDE=
+github.com/companieshouse/private-api-sdk-go v0.1.7 h1:Sk06PhKWJ3KTLeeNefOrIEo5M/Thm4PFVN3Ztd9V/Kw=
+github.com/companieshouse/private-api-sdk-go v0.1.7/go.mod h1:PbDyJJllJm8ZGv2iXUekixIygfz1B7GEteKcJAnagNI=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/handlers/create_insolvency_resource.go
+++ b/handlers/create_insolvency_resource.go
@@ -62,8 +62,18 @@ func HandleCreateInsolvencyResource(svc dao.Service) http.Handler {
 			return
 		}
 
+		// Check with transaction API that provided transaction ID exists
+		err, httpStatus := service.CheckTransactionID(transactionID, req)
+		if err != nil {
+			log.ErrorR(req, fmt.Errorf("transaction id [%s] was not found valid for insolvency request against company [%s] when checking transaction api: [%v]",
+				transactionID, request.CompanyNumber, err))
+			m := models.NewMessageResponse(fmt.Sprintf("transaction id [%s] was not found valid for insolvency: %v", transactionID, err))
+			utils.WriteJSONWithStatus(w, req, m, httpStatus)
+			return
+		}
+
 		// Check with company profile API if company is valid
-		err, httpStatus := service.CheckCompanyInsolvencyValid(&request, req)
+		err, httpStatus = service.CheckCompanyInsolvencyValid(&request, req)
 		if err != nil {
 			log.ErrorR(req, fmt.Errorf("company was not found valid when checking company profile API [%v]", err))
 			m := models.NewMessageResponse(fmt.Sprintf("company [%s] was not found valid for insolvency: %v", request.CompanyNumber, err))
@@ -82,10 +92,17 @@ func HandleCreateInsolvencyResource(svc dao.Service) http.Handler {
 			return
 		}
 
+		// Patch transaction API with new insolvency resource
+		err, httpStatus = service.PatchTransactionWithInsolvencyResource(transactionID, model, req)
+		if err != nil {
+			log.ErrorR(req, fmt.Errorf("error patching transaction api with insolvency resource [%s]: [%v]", model.Links.Self, err))
+			m := models.NewMessageResponse(fmt.Sprintf("error patching transaction api with insolvency resource [%s]: [%v]", model.Links.Self, err))
+			utils.WriteJSONWithStatus(w, req, m, httpStatus)
+			return
+		}
+
 		log.InfoR(req, fmt.Sprintf("successfully added insolvency resource with transaction ID: %s, to mongo", transactionID))
 
 		utils.WriteJSONWithStatus(w, req, transformers.InsolvencyResourceDaoToCreatedResponse(model), http.StatusCreated)
-
-		// TODO: Update transaction API with new insolvency resource
 	})
 }

--- a/service/company_service.go
+++ b/service/company_service.go
@@ -4,13 +4,10 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/companieshouse/insolvency-api/constants"
-
-	"github.com/companieshouse/insolvency-api/models"
-
 	"github.com/companieshouse/api-sdk-go/companieshouseapi"
-
 	"github.com/companieshouse/go-sdk-manager/manager"
+	"github.com/companieshouse/insolvency-api/constants"
+	"github.com/companieshouse/insolvency-api/models"
 )
 
 // CheckCompanyInsolvencyValid will check that the company is valid to be made insolvent against the company profile api
@@ -39,7 +36,7 @@ func CheckCompanyInsolvencyValid(insolvencyRequest *models.InsolvencyRequest, re
 	}
 
 	// If no errors then the company is valid for insolvency
-	return nil, http.StatusOK
+	return nil, companyProfile.HTTPStatusCode
 
 }
 

--- a/service/transaction_service.go
+++ b/service/transaction_service.go
@@ -1,0 +1,31 @@
+package service
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/companieshouse/go-sdk-manager/manager"
+)
+
+// CheckTransactionID will check with the transaction api that the provided transaction id exists
+func CheckTransactionID(transactionID string, req *http.Request) (error, int) {
+
+	// Create SDK session
+	api, err := manager.GetPrivateSDK(req)
+	if err != nil {
+		return fmt.Errorf("error creating SDK to call transaction api: [%v]", err.Error()), http.StatusInternalServerError
+	}
+
+	// Call transaction api to retrieve details of the transaction
+	transactionProfile, err := api.Transaction.Get(transactionID).Do()
+	if err != nil {
+		// If 404 then return the transaction not found
+		if transactionProfile.HTTPStatusCode == http.StatusNotFound {
+			return fmt.Errorf("transaction not found"), http.StatusNotFound
+		}
+		// Else return that there has been an error contacting the transaction api
+		return fmt.Errorf("error communicating with the transaction api"), transactionProfile.HTTPStatusCode
+	}
+
+	return nil, http.StatusOK
+}

--- a/service/transaction_service.go
+++ b/service/transaction_service.go
@@ -32,7 +32,6 @@ func CheckTransactionID(transactionID string, req *http.Request) (error, int) {
 	return nil, transactionProfile.HTTPStatusCode
 }
 
-//
 // PatchTransactionWithInsolvency will patch the provided transaction with the created insolvency resource
 func PatchTransactionWithInsolvencyResource(transactionID string, insolvencyResource *models.InsolvencyResourceDao, req *http.Request) (error, int) {
 

--- a/service/transaction_service.go
+++ b/service/transaction_service.go
@@ -5,13 +5,15 @@ import (
 	"net/http"
 
 	"github.com/companieshouse/go-sdk-manager/manager"
+	"github.com/companieshouse/insolvency-api/models"
+	"github.com/companieshouse/insolvency-api/transformers"
 )
 
 // CheckTransactionID will check with the transaction api that the provided transaction id exists
 func CheckTransactionID(transactionID string, req *http.Request) (error, int) {
 
 	// Create SDK session
-	api, err := manager.GetPrivateSDK(req)
+	api, err := manager.GetSDK(req)
 	if err != nil {
 		return fmt.Errorf("error creating SDK to call transaction api: [%v]", err.Error()), http.StatusInternalServerError
 	}
@@ -27,5 +29,29 @@ func CheckTransactionID(transactionID string, req *http.Request) (error, int) {
 		return fmt.Errorf("error communicating with the transaction api"), transactionProfile.HTTPStatusCode
 	}
 
-	return nil, http.StatusOK
+	return nil, transactionProfile.HTTPStatusCode
+}
+
+//
+// PatchTransactionWithInsolvency will patch the provided transaction with the created insolvency resource
+func PatchTransactionWithInsolvencyResource(transactionID string, insolvencyResource *models.InsolvencyResourceDao, req *http.Request) (error, int) {
+
+	// Create Private SDK session
+	api, err := manager.GetPrivateSDK(req)
+	if err != nil {
+		return fmt.Errorf("error creating SDK to call transaction api: [%v]", err.Error()), http.StatusInternalServerError
+	}
+
+	// Patch transaction api with insolvency resource
+	transactionProfile, err := api.Transaction.Patch(transactionID, transformers.InsolvencyResourceDaoToTransactionResource(insolvencyResource)).Do()
+	if err != nil {
+		// If 404 then return the transaction not found
+		if transactionProfile.HTTPStatusCode == http.StatusNotFound {
+			return fmt.Errorf("transaction not found"), http.StatusNotFound
+		}
+		// Else return that there has been an error contacting the transaction api
+		return fmt.Errorf("error communication with the transaction api"), transactionProfile.HTTPStatusCode
+	}
+
+	return nil, transactionProfile.HTTPStatusCode
 }

--- a/service/transaction_service_test.go
+++ b/service/transaction_service_test.go
@@ -1,0 +1,117 @@
+package service
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/companieshouse/insolvency-api/constants"
+	"github.com/companieshouse/insolvency-api/models"
+	"github.com/companieshouse/insolvency-api/transformers"
+
+	"github.com/jarcoal/httpmock"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func incomingInsolvencyResourceDao() *models.InsolvencyResourceDao {
+	request := incomingInsolvencyRequest("01234567", "companyName", constants.CVL.String())
+	return transformers.InsolvencyResourceRequestToDB(request, "87654321")
+}
+
+func transactionProfileResponse() string {
+	return `
+{
+ "id": "87654321",
+ "company_name": "companyName",
+ "company_number": "01234567"
+}
+`
+}
+
+func TestUnitCheckTransactionID(t *testing.T) {
+
+	Convey("CheckTransactionIDFromTransactionAPI", t, func() {
+
+		apiURL := "https://api.companieshouse.gov.uk"
+
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+
+		Convey("Transaction cannot be found on transaction api", func() {
+			defer httpmock.Reset()
+
+			httpmock.RegisterResponder(http.MethodGet, apiURL+"/transactions/87654321", httpmock.NewStringResponder(http.StatusNotFound, "Message: Transaction not found"))
+
+			err, statusCode := CheckTransactionID("87654321", &http.Request{})
+			So(err, ShouldNotBeNil)
+			So(statusCode, ShouldEqual, http.StatusNotFound)
+			So(err.Error(), ShouldEqual, `transaction not found`)
+		})
+
+		Convey("Error contacting the transaction api", func() {
+			defer httpmock.Reset()
+
+			httpmock.RegisterResponder(http.MethodGet, apiURL+"/transactions/87654321", httpmock.NewStringResponder(http.StatusTeapot, ""))
+
+			err, statusCode := CheckTransactionID("87654321", &http.Request{})
+			So(err, ShouldNotBeNil)
+			So(statusCode, ShouldEqual, http.StatusTeapot)
+			So(err.Error(), ShouldEqual, `error communicating with the transaction api`)
+		})
+
+		Convey("Provided transaction successfully returned", func() {
+			defer httpmock.Reset()
+
+			httpmock.RegisterResponder(http.MethodGet, apiURL+"/transactions/87654321", httpmock.NewStringResponder(http.StatusOK, transactionProfileResponse()))
+
+			err, statusCode := CheckTransactionID("87654321", &http.Request{})
+
+			So(err, ShouldBeNil)
+			So(statusCode, ShouldEqual, http.StatusOK)
+		})
+	})
+}
+
+func TestUnitPatchTransactionWithInsolvencyResource(t *testing.T) {
+
+	Convey("PatchTransactionWithInsolvencyResourceOnTransactionAPI", t, func() {
+
+		privateApiURL := "http://localhost:4001"
+
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+
+		Convey("Transaction cannot be found on transaction api", func() {
+			defer httpmock.Reset()
+
+			httpmock.RegisterResponder(http.MethodPatch, privateApiURL+"/private/transactions/87654321", httpmock.NewStringResponder(http.StatusNotFound, "Message: Transaction not found"))
+
+			err, statusCode := PatchTransactionWithInsolvencyResource("87654321", incomingInsolvencyResourceDao(), &http.Request{})
+			So(err, ShouldNotBeNil)
+			So(statusCode, ShouldEqual, http.StatusNotFound)
+			So(err.Error(), ShouldEqual, `transaction not found`)
+		})
+
+		Convey("Error contacting the transaction api", func() {
+			defer httpmock.Reset()
+
+			httpmock.RegisterResponder(http.MethodPatch, privateApiURL+"/private/transactions/87654321", httpmock.NewStringResponder(http.StatusTeapot, ""))
+
+			err, statusCode := PatchTransactionWithInsolvencyResource("87654321", incomingInsolvencyResourceDao(), &http.Request{})
+			So(err, ShouldNotBeNil)
+			So(statusCode, ShouldEqual, http.StatusTeapot)
+			So(err.Error(), ShouldEqual, `error communication with the transaction api`)
+		})
+
+		Convey("Provided transaction successfully patched", func() {
+			defer httpmock.Reset()
+
+			httpmock.RegisterResponder(http.MethodPatch, privateApiURL+"/private/transactions/87654321", httpmock.NewStringResponder(http.StatusOK, transactionProfileResponse()))
+
+			err, statusCode := PatchTransactionWithInsolvencyResource("87654321", incomingInsolvencyResourceDao(), &http.Request{})
+
+			So(err, ShouldBeNil)
+			So(statusCode, ShouldEqual, http.StatusOK)
+		})
+	})
+}

--- a/transformers/transaction_resource.go
+++ b/transformers/transaction_resource.go
@@ -1,0 +1,28 @@
+package transformers
+
+import (
+	"github.com/companieshouse/api-sdk-go/apicore"
+	"github.com/companieshouse/insolvency-api/models"
+	"github.com/companieshouse/private-api-sdk-go/companieshouseapi"
+)
+
+// InsolvencyResourceDaoToTransactionResource takes the dao for an insolvency request and converts it to
+// a transaction resource
+func InsolvencyResourceDaoToTransactionResource(req *models.InsolvencyResourceDao) *companieshouseapi.Transaction {
+
+	// Generate insolvency resource for the transaction
+	transactionResource := make(map[string]*companieshouseapi.Resource)
+	transactionResource[req.Links.Self] = &companieshouseapi.Resource{
+		Kind: req.Kind,
+		Links: companieshouseapi.Links{
+			Resource: req.Links.Self,
+		},
+		Marshal: apicore.Marshal{},
+	}
+
+	transaction := &companieshouseapi.Transaction{
+		Resources: transactionResource,
+	}
+
+	return transaction
+}

--- a/transformers/transaction_resource_test.go
+++ b/transformers/transaction_resource_test.go
@@ -1,0 +1,25 @@
+package transformers
+
+import (
+	"testing"
+
+	"github.com/companieshouse/insolvency-api/models"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestUnitInsolvencyResourceDaoToTransactionResource(t *testing.T) {
+	Convey("field mappings are correct", t, func() {
+
+		incomingRequest := &models.InsolvencyResourceDao{
+			Links: models.InsolvencyResourceLinksDao{
+				Self: "/transactions/87654321/insolvency",
+			},
+			Kind: "insolvency-resource#insolvency-resource",
+		}
+
+		response := InsolvencyResourceDaoToTransactionResource(incomingRequest)
+
+		So(response.Resources, ShouldHaveLength, 1)
+	})
+}


### PR DESCRIPTION
When the insolvency resource is created send a PATCH request to the transaction resource to update it with the newly created resource

Resolves: IEP-150