### PR TITLE
Create new validation endpoint 

### DIFF
--- a/handlers/insolvency_resource.go
+++ b/handlers/insolvency_resource.go
@@ -104,6 +104,7 @@ func HandleCreateInsolvencyResource(svc dao.Service) http.Handler {
 	})
 }
 
+// HandleGetValidationStatus returns whether a created insolvency case is acceptable to be closed by the transaction API
 func HandleGetValidationStatus(svc dao.Service) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 

--- a/handlers/register.go
+++ b/handlers/register.go
@@ -26,6 +26,7 @@ func Register(mainRouter *mux.Router, svc dao.Service) {
 
 	// Declare endpoint URIs
 	appRouter.Handle("/{transaction_id}/insolvency", HandleCreateInsolvencyResource(svc)).Methods(http.MethodPost).Name("createInsolvencyResource")
+	appRouter.Handle("/{transaction_id}/insolvency/validation-status", HandleGetValidationStatus(svc)).Methods(http.MethodGet).Name("getValidationStatus")
 	appRouter.Handle("/{transaction_id}/insolvency/practitioners", HandleCreatePractitionersResource(svc)).Methods(http.MethodPost).Name("createPractitionersResource")
 	appRouter.Handle("/{transaction_id}/insolvency/practitioners", HandleGetPractitionerResources(svc)).Methods(http.MethodGet).Name("getPractitionerResources")
 	appRouter.Handle("/{transaction_id}/insolvency/practitioners/{practitioner_id}", HandleDeletePractitioner(svc)).Methods(http.MethodDelete).Name("deletePractitioner")

--- a/handlers/register_test.go
+++ b/handlers/register_test.go
@@ -22,6 +22,7 @@ func TestUnitRegisterRoutes(t *testing.T) {
 
 		So(router.GetRoute("healthcheck"), ShouldNotBeNil)
 		So(router.GetRoute("createInsolvencyResource"), ShouldNotBeNil)
+		So(router.GetRoute("getValidationStatus"), ShouldNotBeNil)
 		So(router.GetRoute("createPractitionersResource"), ShouldNotBeNil)
 		So(router.GetRoute("getPractitionerResources"), ShouldNotBeNil)
 		So(router.GetRoute("deletePractitioner"), ShouldNotBeNil)

--- a/models/response_entities.go
+++ b/models/response_entities.go
@@ -56,6 +56,35 @@ type AppointedPractitionerLinksResource struct {
 	Self string `json:"self"`
 }
 
+// ValidationStatusResponse is the object returned when checking the validation of a case
+type ValidationStatusResponse struct {
+	IsValid bool                              `json:"is_valid"`
+	Errors  []ValidationErrorResponseResource `json:"errors"`
+}
+
+// NewValidationStatusResponse - convenience function for creating a validation response resource
+func NewValidationStatusResponse(isValid bool, errors *[]ValidationErrorResponseResource) *ValidationStatusResponse {
+	return &ValidationStatusResponse{IsValid: isValid, Errors: *errors}
+}
+
+// ValidationResponseResource contains the details of an error when checking the validation for closing a case - as expected by transaction api
+type ValidationErrorResponseResource struct {
+	Error        string `json:"error"`
+	Location     string `json:"location"`
+	LocationType string `json:"location_type"`
+	Type         string `json:"type"`
+}
+
+// NewValidationErrorResponse - convenience function for creating validation error responses
+func NewValidationErrorResponse(validationError, location string) *ValidationErrorResponseResource {
+	return &ValidationErrorResponseResource{
+		Error:        validationError,
+		Location:     location,
+		LocationType: "json-path",
+		Type:         "ch:validation",
+	}
+}
+
 // ResponseResource is the object returned in an error case
 type ResponseResource struct {
 	Message string `json:"message"`

--- a/service/insolvency_service.go
+++ b/service/insolvency_service.go
@@ -1,0 +1,36 @@
+package service
+
+import (
+	"fmt"
+
+	"github.com/companieshouse/insolvency-api/models"
+
+	"github.com/companieshouse/chs.go/log"
+	"github.com/companieshouse/insolvency-api/dao"
+)
+
+// ValidateInsolvencyDetails checks that an insolvency case is valid and ready for submission which is returned as a boolean
+// Any validation errors found are added to an array to be returned
+func ValidateInsolvencyDetails(svc dao.Service, transactionID string) (bool, *[]models.ValidationErrorResponseResource) {
+
+	validationErrors := make([]models.ValidationErrorResponseResource, 0)
+
+	// Retrieve details for the insolvency resource from MongoDB
+	_, err := svc.GetInsolvencyResource(transactionID)
+	if err != nil {
+		log.Error(fmt.Errorf("error getting insolvency resource from DB [%s]", err))
+		validationErrors = addValidationError(validationErrors, fmt.Sprintf("error getting insolvency resource from DB: [%s]", err), "insolvency case")
+
+		// If there is an error retrieving the insolvency resource return without running any other validations as they will all fail
+		return false, &validationErrors
+	}
+
+	//TODO: Validation checks for insolvency case
+
+	return true, &validationErrors
+}
+
+// addValidationError adds any validation errors to an array of existing errors
+func addValidationError(validationErrors []models.ValidationErrorResponseResource, validationError, errorLocation string) []models.ValidationErrorResponseResource {
+	return append(validationErrors, *models.NewValidationErrorResponse(validationError, errorLocation))
+}

--- a/service/insolvency_service.go
+++ b/service/insolvency_service.go
@@ -3,10 +3,9 @@ package service
 import (
 	"fmt"
 
-	"github.com/companieshouse/insolvency-api/models"
-
 	"github.com/companieshouse/chs.go/log"
 	"github.com/companieshouse/insolvency-api/dao"
+	"github.com/companieshouse/insolvency-api/models"
 )
 
 // ValidateInsolvencyDetails checks that an insolvency case is valid and ready for submission which is returned as a boolean
@@ -15,7 +14,7 @@ func ValidateInsolvencyDetails(svc dao.Service, transactionID string) (bool, *[]
 
 	validationErrors := make([]models.ValidationErrorResponseResource, 0)
 
-	// Retrieve details for the insolvency resource from MongoDB
+	// Retrieve details for the insolvency resource from DB
 	_, err := svc.GetInsolvencyResource(transactionID)
 	if err != nil {
 		log.Error(fmt.Errorf("error getting insolvency resource from DB [%s]", err))

--- a/service/insolvency_service_test.go
+++ b/service/insolvency_service_test.go
@@ -1,0 +1,71 @@
+package service
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/companieshouse/insolvency-api/models"
+	"go.mongodb.org/mongo-driver/bson/primitive"
+
+	"github.com/companieshouse/insolvency-api/mocks"
+	"github.com/golang/mock/gomock"
+	"github.com/jarcoal/httpmock"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+var transactionID = "12345678"
+var companyNumber = "01234567"
+var companyName = "companyName"
+
+func createInsolvencyResource() models.InsolvencyResourceDao {
+	return models.InsolvencyResourceDao{
+		ID:            primitive.ObjectID{},
+		TransactionID: transactionID,
+		Etag:          "etag1234",
+		Kind:          "insolvency",
+		Data: models.InsolvencyResourceDaoData{
+			CompanyNumber: companyNumber,
+			CompanyName:   companyName,
+			CaseType:      "insolvency",
+		},
+		Links: models.InsolvencyResourceLinksDao{
+			Self:             "/transactions/123456789/insolvency",
+			ValidationStatus: "/transactions/123456789/insolvency/validation-status",
+		},
+	}
+}
+
+func TestValidateInsolvencyDetails(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	Convey("error getting insolvency resource from database", t, func() {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+		mockService := mocks.NewMockService(mockCtrl)
+
+		// Expect GetInsolvencyResource to be called once and return an error for the insolvency case
+		mockService.EXPECT().GetInsolvencyResource(transactionID).Return(createInsolvencyResource(), errors.New("insolvency case does not exist")).Times(1)
+
+		isValid, validationErrors := ValidateInsolvencyDetails(mockService, transactionID)
+
+		So(isValid, ShouldBeFalse)
+		So(validationErrors, ShouldHaveLength, 1)
+		So((*validationErrors)[0].Error, ShouldContainSubstring, "error getting insolvency resource from DB: [insolvency case does not exist]")
+		So((*validationErrors)[0].Location, ShouldContainSubstring, "insolvency case")
+	})
+
+	Convey("successfully returned valid insolvency resource", t, func() {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+		mockService := mocks.NewMockService(mockCtrl)
+
+		// Expect GetInsolvencyResource to be called once and return a valid insolvency case
+		mockService.EXPECT().GetInsolvencyResource(transactionID).Return(createInsolvencyResource(), nil).Times(1)
+
+		isValid, validationErrors := ValidateInsolvencyDetails(mockService, transactionID)
+
+		So(isValid, ShouldBeTrue)
+		So(validationErrors, ShouldHaveLength, 0)
+	})
+}

--- a/service/insolvency_service_test.go
+++ b/service/insolvency_service_test.go
@@ -4,13 +4,12 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/companieshouse/insolvency-api/models"
-	"go.mongodb.org/mongo-driver/bson/primitive"
-
 	"github.com/companieshouse/insolvency-api/mocks"
+	"github.com/companieshouse/insolvency-api/models"
 	"github.com/golang/mock/gomock"
 	"github.com/jarcoal/httpmock"
 	. "github.com/smartystreets/goconvey/convey"
+	"go.mongodb.org/mongo-driver/bson/primitive"
 )
 
 var transactionID = "12345678"

--- a/transformers/transaction_resource.go
+++ b/transformers/transaction_resource.go
@@ -15,7 +15,8 @@ func InsolvencyResourceDaoToTransactionResource(req *models.InsolvencyResourceDa
 	transactionResource[req.Links.Self] = &companieshouseapi.Resource{
 		Kind: req.Kind,
 		Links: companieshouseapi.Links{
-			Resource: req.Links.Self,
+			Resource:         req.Links.Self,
+			ValidationStatus: req.Links.ValidationStatus,
 		},
 		Marshal: apicore.Marshal{},
 	}

--- a/transformers/transaction_resource_test.go
+++ b/transformers/transaction_resource_test.go
@@ -13,7 +13,8 @@ func TestUnitInsolvencyResourceDaoToTransactionResource(t *testing.T) {
 
 		incomingRequest := &models.InsolvencyResourceDao{
 			Links: models.InsolvencyResourceLinksDao{
-				Self: "/transactions/87654321/insolvency",
+				Self:             "/transactions/87654321/insolvency",
+				ValidationStatus: "/transactions/87654321/insolvency/validation-status",
 			},
 			Kind: "insolvency-resource#insolvency-resource",
 		}


### PR DESCRIPTION
Creates a new validation endpoint for the transaction api to call before closing the resource. 

Also includes an update to the data sent to the transaction api to include this new `validation-status` endpoint.

The response from this endpoint should always be 200 provided the check has been successfully made. The status response does not indicate if the resource is valid or not, that data is held in the `errors` array. 

Resolves: IEP-224