### PR TITLE
Feature/bug fix empty resource blocks

### DIFF
--- a/dao/mongo.go
+++ b/dao/mongo.go
@@ -660,7 +660,7 @@ func (m *MongoService) GetResolutionResource(transactionID string) (models.Resol
 		return models.ResolutionResourceDao{}, err
 	}
 
-	return insolvencyResource.Data.Resolution, nil
+	return *insolvencyResource.Data.Resolution, nil
 }
 
 // DeleteResolutionResource deletes an resource filed for an Insolvency Case

--- a/models/data_entities.go
+++ b/models/data_entities.go
@@ -14,13 +14,13 @@ type InsolvencyResourceDao struct {
 
 // InsolvencyResourceDaoData contains the data for the insolvency resource in Mongo
 type InsolvencyResourceDaoData struct {
-	CompanyNumber      string                        `bson:"company_number"`
-	CaseType           string                        `bson:"case_type"`
-	CompanyName        string                        `bson:"company_name"`
-	Practitioners      []PractitionerResourceDao     `bson:"practitioners,omitempty"`
-	Attachments        []AttachmentResourceDao       `bson:"attachments,omitempty"`
-	Resolution         ResolutionResourceDao         `bson:"resolution,omitempty"`
-	StatementOfAffairs StatementOfAffairsResourceDao `bson:"statement-of-affairs,omitempty"`
+	CompanyNumber      string                         `bson:"company_number"`
+	CaseType           string                         `bson:"case_type"`
+	CompanyName        string                         `bson:"company_name"`
+	Practitioners      []PractitionerResourceDao      `bson:"practitioners,omitempty"`
+	Attachments        []AttachmentResourceDao        `bson:"attachments,omitempty"`
+	Resolution         *ResolutionResourceDao         `bson:"resolution,omitempty"`
+	StatementOfAffairs *StatementOfAffairsResourceDao `bson:"statement-of-affairs,omitempty"`
 }
 
 // InsolvencyResourceLinksDao contains the links for the insolvency resource

--- a/service/insolvency_service_test.go
+++ b/service/insolvency_service_test.go
@@ -273,7 +273,11 @@ func TestUnitValidateInsolvencyDetails(t *testing.T) {
 		insolvencyCase := createInsolvencyResource()
 		// Set attachment type to "resolution"
 		insolvencyCase.Data.Attachments[0].Type = "resolution"
-		insolvencyCase.Data.Resolution.DateOfResolution = "2021-06-06"
+
+		insolvencyCase.Data.Resolution = &models.ResolutionResourceDao{
+			DateOfResolution: "2021-06-06",
+		}
+
 		mockService.EXPECT().GetInsolvencyResource(transactionID).Return(insolvencyCase, nil).Times(1)
 
 		isValid, validationErrors := ValidateInsolvencyDetails(mockService, transactionID)
@@ -295,7 +299,7 @@ func TestUnitValidateInsolvencyDetails(t *testing.T) {
 						Type: "resolution",
 					},
 				},
-				Resolution: models.ResolutionResourceDao{
+				Resolution: &models.ResolutionResourceDao{
 					DateOfResolution: "2021-06-06",
 				},
 			},
@@ -321,7 +325,7 @@ func TestUnitValidateInsolvencyDetails(t *testing.T) {
 						Type: "resolution",
 					},
 				},
-				Resolution: models.ResolutionResourceDao{
+				Resolution: &models.ResolutionResourceDao{
 					DateOfResolution: "2021-06-06",
 				},
 			},
@@ -471,6 +475,10 @@ func TestUnitValidateInsolvencyDetails(t *testing.T) {
 		insolvencyCase := createInsolvencyResource()
 		insolvencyCase.Data.Attachments[0].Type = "resolution"
 
+		insolvencyCase.Data.Resolution = &models.ResolutionResourceDao{
+			DateOfResolution: "",
+		}
+
 		mockService.EXPECT().GetInsolvencyResource(transactionID).Return(insolvencyCase, nil).Times(1)
 
 		isValid, validationErrors := ValidateInsolvencyDetails(mockService, transactionID)
@@ -489,8 +497,9 @@ func TestUnitValidateInsolvencyDetails(t *testing.T) {
 		// Expect GetInsolvencyResource to be called once and return a valid insolvency case
 		insolvencyCase := createInsolvencyResource()
 		insolvencyCase.Data.Attachments[0].Type = "resolution"
-		insolvencyCase.Data.Resolution.DateOfResolution = "2021-06-06"
-
+		insolvencyCase.Data.Resolution = &models.ResolutionResourceDao{
+			DateOfResolution: "2021-06-06",
+		}
 		mockService.EXPECT().GetInsolvencyResource(transactionID).Return(insolvencyCase, nil).Times(1)
 
 		isValid, validationErrors := ValidateInsolvencyDetails(mockService, transactionID)


### PR DESCRIPTION
fixes bug where creating an insolvency case would create resolution and SoA resources even though they were not supplied. Changed data entity to reference them as pointers so they can be omitted when empty.