### PR TITLE
Remove duplicated DB call

### DIFF
--- a/handlers/insolvency_resource_test.go
+++ b/handlers/insolvency_resource_test.go
@@ -60,14 +60,14 @@ var transactionProfileResponseClosed = `
 }
 `
 
-func serveHandleCreateInsolvencyResource(body []byte, service dao.Service, tranIdSet bool) *httptest.ResponseRecorder {
+func serveHandleCreateInsolvencyResource(body []byte, service dao.Service, tranIDSet bool) *httptest.ResponseRecorder {
 
 	ctx := context.WithValue(context.Background(), httpsession.ContextKeySession, &session.Session{})
 	handler := HandleCreateInsolvencyResource(service)
 
 	req := httptest.NewRequest(http.MethodPost, "/test", bytes.NewReader(body)).WithContext(ctx)
 
-	if tranIdSet {
+	if tranIDSet {
 		req = mux.SetURLVars(req, map[string]string{"transaction_id": transactionID})
 	}
 
@@ -469,13 +469,12 @@ func TestUnitHandleGetValidationStatus(t *testing.T) {
 		mockService := mock_dao.NewMockService(mockCtrl)
 
 		// Expect GetInsolvencyResource to be called once and return an error for the insolvency case
-		mockService.EXPECT().GetInsolvencyResource(transactionID).Return(createInsolvencyResource(), errors.New("insolvency case does not exist")).Times(2)
+		mockService.EXPECT().GetInsolvencyResource(transactionID).Return(createInsolvencyResource(), errors.New("insolvency case does not exist")).Times(1)
 
 		res := serveHandleGetValidationStatus(mockService, true)
 
-		So(res.Code, ShouldEqual, http.StatusOK)
-		So(res.Body.String(), ShouldContainSubstring, `"is_valid":false`)
-		So(res.Body.String(), ShouldContainSubstring, `"error":"error getting insolvency resource from DB: [insolvency case does not exist]"`)
+		So(res.Code, ShouldEqual, http.StatusInternalServerError)
+		So(res.Body.String(), ShouldContainSubstring, `there was a problem handling your request`)
 	})
 
 	Convey("Case is found valid for submission", t, func() {
@@ -486,7 +485,7 @@ func TestUnitHandleGetValidationStatus(t *testing.T) {
 		mockService := mock_dao.NewMockService(mockCtrl)
 
 		// Expect GetInsolvencyResource to be called once and return a valid insolvency case
-		mockService.EXPECT().GetInsolvencyResource(transactionID).Return(createInsolvencyResource(), nil).Times(2)
+		mockService.EXPECT().GetInsolvencyResource(transactionID).Return(createInsolvencyResource(), nil).Times(1)
 
 		res := serveHandleGetValidationStatus(mockService, true)
 

--- a/service/insolvency_service.go
+++ b/service/insolvency_service.go
@@ -12,19 +12,9 @@ import (
 
 // ValidateInsolvencyDetails checks that an insolvency case is valid and ready for submission which is returned as a boolean
 // Any validation errors found are added to an array to be returned
-func ValidateInsolvencyDetails(svc dao.Service, transactionID string) (bool, *[]models.ValidationErrorResponseResource) {
+func ValidateInsolvencyDetails(insolvencyResource models.InsolvencyResourceDao) (bool, *[]models.ValidationErrorResponseResource) {
 
 	validationErrors := make([]models.ValidationErrorResponseResource, 0)
-
-	// Retrieve details for the insolvency resource from DB
-	insolvencyResource, err := svc.GetInsolvencyResource(transactionID)
-	if err != nil {
-		log.Error(fmt.Errorf("error getting insolvency resource from DB [%s]", err))
-		validationErrors = addValidationError(validationErrors, fmt.Sprintf("error getting insolvency resource from DB: [%s]", err), "insolvency case")
-
-		// If there is an error retrieving the insolvency resource return without running any other validations as they will all fail
-		return false, &validationErrors
-	}
 
 	// Check if there is one practitioner appointed and if there is, ensure that all practitioners are appointed
 	hasAppointedPractitioner := false
@@ -190,19 +180,10 @@ func addValidationError(validationErrors []models.ValidationErrorResponseResourc
 
 // ValidateAntivirus checks that attachments on an insolvency case pass the antivirus check and are ready for submission which is returned as a boolean
 // Any validation errors found are added to an array to be returned
-func ValidateAntivirus(svc dao.Service, transactionID string, req *http.Request) (bool, *[]models.ValidationErrorResponseResource) {
+func ValidateAntivirus(svc dao.Service, insolvencyResource models.InsolvencyResourceDao, req *http.Request) (bool, *[]models.ValidationErrorResponseResource) {
 
 	validationErrors := make([]models.ValidationErrorResponseResource, 0)
 
-	// Retrieve details for the insolvency resource from DB
-	insolvencyResource, err := svc.GetInsolvencyResource(transactionID)
-	if err != nil {
-		log.Error(fmt.Errorf("error getting insolvency resource from DB [%s]", err))
-		validationErrors = addValidationError(validationErrors, fmt.Sprintf("error getting insolvency resource from DB: [%s]", err), "insolvency case")
-
-		// If there is an error retrieving the insolvency resource return without running any other validation as it will fail
-		return false, &validationErrors
-	}
 	// Check if the insolvency resource has attachments, if not then skip validation
 	if len(insolvencyResource.Data.Attachments) != 0 {
 


### PR DESCRIPTION
`svc.GetInsolvencyResource` was being called twice.
Once within `service.ValidateInsolvencyDetails` and again within `service.ValidateAntivirus`

This change moves the `svc.GetInsolvencyResource` call to be a single call before the two validation functions.