### PR TITLE
Fix bug with validation endpoint returning a 500 when insolvency case is not found

### DIFF
--- a/handlers/insolvency_resource.go
+++ b/handlers/insolvency_resource.go
@@ -123,7 +123,7 @@ func HandleGetValidationStatus(svc dao.Service) http.Handler {
 		insolvencyResource, err := svc.GetInsolvencyResource(transactionID)
 		if err != nil {
 			// Check if insolvency case was not found
-			if err == fmt.Errorf("there was a problem handling your request for transaction [%s] - insolvency case not found", transactionID) {
+			if err.Error() == fmt.Sprintf("there was a problem handling your request for transaction [%s] - insolvency case not found", transactionID) {
 				message := fmt.Sprintf("insolvency case with transactionID [%s] not found", transactionID)
 				log.Info(message)
 				m := models.NewMessageResponse(message)

--- a/handlers/insolvency_resource_test.go
+++ b/handlers/insolvency_resource_test.go
@@ -473,8 +473,8 @@ func TestUnitHandleGetValidationStatus(t *testing.T) {
 
 		res := serveHandleGetValidationStatus(mockService, true)
 
-		So(res.Code, ShouldEqual, http.StatusInternalServerError)
-		So(res.Body.String(), ShouldContainSubstring, `there was a problem handling your request`)
+		So(res.Code, ShouldEqual, http.StatusOK)
+		So(res.Body.String(), ShouldContainSubstring, fmt.Sprintf("insolvency case with transactionID [%s] not found", transactionID))
 	})
 
 	Convey("Error returning insolvency case from DB", t, func() {

--- a/handlers/insolvency_resource_test.go
+++ b/handlers/insolvency_resource_test.go
@@ -461,7 +461,7 @@ func TestUnitHandleGetValidationStatus(t *testing.T) {
 		So(res.Code, ShouldEqual, http.StatusBadRequest)
 	})
 
-	Convey("Case is not found valid for submission - error returning insolvency case from mongoDB", t, func() {
+	Convey("Insolvency case not found in DB", t, func() {
 		httpmock.Activate()
 		mockCtrl := gomock.NewController(t)
 		defer httpmock.DeactivateAndReset()
@@ -469,7 +469,23 @@ func TestUnitHandleGetValidationStatus(t *testing.T) {
 		mockService := mock_dao.NewMockService(mockCtrl)
 
 		// Expect GetInsolvencyResource to be called once and return an error for the insolvency case
-		mockService.EXPECT().GetInsolvencyResource(transactionID).Return(createInsolvencyResource(), errors.New("insolvency case does not exist")).Times(1)
+		mockService.EXPECT().GetInsolvencyResource(transactionID).Return(models.InsolvencyResourceDao{}, fmt.Errorf("there was a problem handling your request for transaction [%s] - insolvency case not found", transactionID)).Times(1)
+
+		res := serveHandleGetValidationStatus(mockService, true)
+
+		So(res.Code, ShouldEqual, http.StatusInternalServerError)
+		So(res.Body.String(), ShouldContainSubstring, `there was a problem handling your request`)
+	})
+
+	Convey("Error returning insolvency case from DB", t, func() {
+		httpmock.Activate()
+		mockCtrl := gomock.NewController(t)
+		defer httpmock.DeactivateAndReset()
+		defer mockCtrl.Finish()
+		mockService := mock_dao.NewMockService(mockCtrl)
+
+		// Expect GetInsolvencyResource to be called once and return an error for the insolvency case
+		mockService.EXPECT().GetInsolvencyResource(transactionID).Return(models.InsolvencyResourceDao{}, errors.New("error getting insolvency case from DB")).Times(1)
 
 		res := serveHandleGetValidationStatus(mockService, true)
 

--- a/service/insolvency_service.go
+++ b/service/insolvency_service.go
@@ -238,18 +238,9 @@ func addValidationError(validationErrors []models.ValidationErrorResponseResourc
 
 // ValidateAntivirus checks that attachments on an insolvency case pass the antivirus check and are ready for submission
 // Any validation errors found are added to an array to be returned
-func ValidateAntivirus(svc dao.Service, insolvencyResource models.InsolvencyResourceDao, transactionID string, req *http.Request) *[]models.ValidationErrorResponseResource {
+func ValidateAntivirus(svc dao.Service, insolvencyResource models.InsolvencyResourceDao, req *http.Request) *[]models.ValidationErrorResponseResource {
 
 	validationErrors := make([]models.ValidationErrorResponseResource, 0)
-
-	// Check if transactionID is empty to check if insolvency resource was found in DB
-	if insolvencyResource.TransactionID == "" {
-		log.Info(fmt.Sprintf("insolvency case with transactionID [%s] not found", transactionID))
-		validationErrors = addValidationError(validationErrors, "insolvency case not found", "insolvency case")
-
-		// If there is an error retrieving the insolvency resource return without running any other validation as it will fail
-		return &validationErrors
-	}
 
 	// Check if the insolvency resource has attachments, if not then skip validation
 	if len(insolvencyResource.Data.Attachments) != 0 {

--- a/service/insolvency_service_test.go
+++ b/service/insolvency_service_test.go
@@ -657,19 +657,6 @@ func TestUnitValidateAntivirus(t *testing.T) {
 	httpmock.Activate()
 	defer httpmock.DeactivateAndReset()
 
-	Convey("insolvency resource not found", t, func() {
-		mockCtrl := gomock.NewController(t)
-		defer mockCtrl.Finish()
-		mockService := mocks.NewMockService(mockCtrl)
-
-		insolvencyCase := models.InsolvencyResourceDao{}
-
-		validationErrors := ValidateAntivirus(mockService, insolvencyCase, transactionID, req)
-		So(validationErrors, ShouldHaveLength, 1)
-		So((*validationErrors)[0].Error, ShouldContainSubstring, "insolvency case not found")
-		So((*validationErrors)[0].Location, ShouldContainSubstring, "insolvency case")
-	})
-
 	Convey("error - antivirus check has not been completed", t, func() {
 		mockCtrl := gomock.NewController(t)
 		defer mockCtrl.Finish()
@@ -689,7 +676,7 @@ func TestUnitValidateAntivirus(t *testing.T) {
 
 		mockService.EXPECT().UpdateAttachmentStatus(transactionID, insolvencyCase.Data.Attachments[0].ID, "integrity_failed").Return(http.StatusNoContent, nil).Times(2)
 
-		validationErrors := ValidateAntivirus(mockService, insolvencyCase, transactionID, req)
+		validationErrors := ValidateAntivirus(mockService, insolvencyCase, req)
 
 		So(validationErrors, ShouldHaveLength, 1)
 		So((*validationErrors)[0].Error, ShouldContainSubstring, fmt.Sprintf("error - antivirus check has failed on insolvency case with transaction id [%s], attachments have not been scanned", insolvencyCase.TransactionID))
@@ -715,7 +702,7 @@ func TestUnitValidateAntivirus(t *testing.T) {
 
 		mockService.EXPECT().UpdateAttachmentStatus(transactionID, insolvencyCase.Data.Attachments[0].ID, "integrity_failed").Return(http.StatusNoContent, nil).Times(2)
 
-		validationErrors := ValidateAntivirus(mockService, insolvencyCase, transactionID, req)
+		validationErrors := ValidateAntivirus(mockService, insolvencyCase, req)
 
 		So(validationErrors, ShouldHaveLength, 1)
 		So((*validationErrors)[0].Error, ShouldContainSubstring, fmt.Sprintf("error - antivirus check has failed on insolvency case with transaction id [%s], virus detected", insolvencyCase.TransactionID))
@@ -741,7 +728,7 @@ func TestUnitValidateAntivirus(t *testing.T) {
 
 		mockService.EXPECT().UpdateAttachmentStatus(transactionID, insolvencyCase.Data.Attachments[0].ID, "processed").Return(http.StatusNoContent, nil).Times(2)
 
-		validationErrors := ValidateAntivirus(mockService, insolvencyCase, transactionID, req)
+		validationErrors := ValidateAntivirus(mockService, insolvencyCase, req)
 		So(validationErrors, ShouldHaveLength, 0)
 	})
 }


### PR DESCRIPTION
- Remove redundant checks in Insolvency Service
- Add check to see if case is not found in Insolvency Handler