### PR TITLE
Update Go version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM 169942020521.dkr.ecr.eu-west-1.amazonaws.com/base/golang:1.15-alpine-builder
-FROM 169942020521.dkr.ecr.eu-west-1.amazonaws.com/base/golang:1.15-alpine-runtime
+FROM 169942020521.dkr.ecr.eu-west-1.amazonaws.com/base/golang:1.16-alpine-builder
+FROM 169942020521.dkr.ecr.eu-west-1.amazonaws.com/base/golang:1.16-alpine-runtime
 CMD ["-bind-addr=:10092"]
 EXPOSE 10092

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/companieshouse/insolvency-api
 
-go 1.12
+go 1.16
 
 require (
 	github.com/companieshouse/api-sdk-go v0.1.17


### PR DESCRIPTION
Update Go to version 1.16

http.NewRequestWithContext is being used, which was introduced in 1.13 and was causing a build failure.