### PR TITLE
Upgrade go 1.12 to 1.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM 169942020521.dkr.ecr.eu-west-1.amazonaws.com/base/golang:1.15-alpine-builder
-FROM 169942020521.dkr.ecr.eu-west-1.amazonaws.com/base/golang:1.15-alpine-runtime
+FROM 169942020521.dkr.ecr.eu-west-1.amazonaws.com/base/golang:1.16-alpine-builder
+FROM 169942020521.dkr.ecr.eu-west-1.amazonaws.com/base/golang:1.16-alpine-runtime
 CMD ["-bind-addr=:10092"]
 EXPOSE 10092

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/companieshouse/insolvency-api
 
-go 1.12
+go 1.16
 
 require (
 	github.com/companieshouse/api-sdk-go v0.1.17


### PR DESCRIPTION
Required in order for some of the testing in email_auth_interceptor to work as http.NewRequestWithContext() was only added in Go 1.16