### PR TITLE
Update go SDK manager version and use new internal SDK function

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/companieshouse/api-sdk-go v0.1.17
 	github.com/companieshouse/chs.go v1.2.6
-	github.com/companieshouse/go-sdk-manager v0.1.10
+	github.com/companieshouse/go-sdk-manager v0.1.11
 	github.com/companieshouse/go-session-handler v0.1.5
 	github.com/companieshouse/gofigure v0.1.4
 	github.com/companieshouse/private-api-sdk-go v0.1.9

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/companieshouse/envconf v0.1.0 h1:6EAyUYqBJsduWZQuz1AR8hxG5OwhPK0r3Y6p
 github.com/companieshouse/envconf v0.1.0/go.mod h1:/gP4p46vTAENnqc2vXW441VOjL91ReJv/uqnYBzlaFo=
 github.com/companieshouse/go-sdk-manager v0.1.10 h1:If/z3fbgXR/+rpSSfbUYdQ2i1cbYWjF6PvEhIUuel3k=
 github.com/companieshouse/go-sdk-manager v0.1.10/go.mod h1:+oN76sQ5uwQh/moEDK4r0wR3kHoH+WHuODAxScdbN/U=
+github.com/companieshouse/go-sdk-manager v0.1.11 h1:D0mkpOxp2VcJrz+Oadzg4rLz7sHaQmbOCzBxH4D0mSc=
+github.com/companieshouse/go-sdk-manager v0.1.11/go.mod h1:+oN76sQ5uwQh/moEDK4r0wR3kHoH+WHuODAxScdbN/U=
 github.com/companieshouse/go-session-handler v0.1.1/go.mod h1:SxvarOscnlb8qivxJsjVmROri/7iuCm+Kcs6fglhKEE=
 github.com/companieshouse/go-session-handler v0.1.5 h1:lkiWJLE0hXNrkUawBQ9ul9VnK2qUNGeh9kzuvZXGJs8=
 github.com/companieshouse/go-session-handler v0.1.5/go.mod h1:2lBRj2gEzuXNdgxHqHvq01er1A0MciOsxhW4Ved36lE=

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,6 @@ github.com/companieshouse/chs.go v1.2.6 h1:q5W8JPUDIDBrwiRYl5UefnWK14x4aTC+ZysYy
 github.com/companieshouse/chs.go v1.2.6/go.mod h1:93vQ2qlzSbZenUOFet+pAJzxHdz+w6BF1IvJ56lvC7c=
 github.com/companieshouse/envconf v0.1.0 h1:6EAyUYqBJsduWZQuz1AR8hxG5OwhPK0r3Y6ppcTDBmQ=
 github.com/companieshouse/envconf v0.1.0/go.mod h1:/gP4p46vTAENnqc2vXW441VOjL91ReJv/uqnYBzlaFo=
-github.com/companieshouse/go-sdk-manager v0.1.10 h1:If/z3fbgXR/+rpSSfbUYdQ2i1cbYWjF6PvEhIUuel3k=
-github.com/companieshouse/go-sdk-manager v0.1.10/go.mod h1:+oN76sQ5uwQh/moEDK4r0wR3kHoH+WHuODAxScdbN/U=
 github.com/companieshouse/go-sdk-manager v0.1.11 h1:D0mkpOxp2VcJrz+Oadzg4rLz7sHaQmbOCzBxH4D0mSc=
 github.com/companieshouse/go-sdk-manager v0.1.11/go.mod h1:+oN76sQ5uwQh/moEDK4r0wR3kHoH+WHuODAxScdbN/U=
 github.com/companieshouse/go-session-handler v0.1.1/go.mod h1:SxvarOscnlb8qivxJsjVmROri/7iuCm+Kcs6fglhKEE=
@@ -33,7 +31,6 @@ github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
 github.com/eknkc/amber v0.0.0-20171010120322-cdade1c07385/go.mod h1:0vRUJqYpeSZifjYj7uP3BG/gKcuzL9xWVV/Y+cK33KM=
 github.com/elodina/go-avro v0.0.0-20160406082632-0c8185d9a3ba/go.mod h1:3A7SOsr8WBIpkWUsqzMpR3tIQbanKqxZcis2GSl12Nk=
-github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/go-playground/assert/v2 v2.0.1 h1:MsBgLAaY856+nPRTKrp3/OZK38U/wa0CcBYNjji3q3A=
 github.com/go-playground/assert/v2 v2.0.1/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=

--- a/interceptors/email_auth_interceptor_test.go
+++ b/interceptors/email_auth_interceptor_test.go
@@ -1,0 +1,103 @@
+package interceptors
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/companieshouse/chs.go/authentication"
+	"github.com/jarcoal/httpmock"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func getTestHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, req *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}
+}
+
+func testContext() context.Context {
+	ctx := context.Background()
+	ctx = context.WithValue(
+		ctx,
+		authentication.ContextKeyUserDetails,
+		authentication.AuthUserDetails{Email: "demo@companieshouse.gov.uk"},
+	)
+	return ctx
+}
+
+func invalidTestContext() context.Context {
+	ctx := context.Background()
+	ctx = context.WithValue(
+		ctx,
+		authentication.ContextKeyUserDetails,
+		"invalid",
+	)
+	return ctx
+}
+
+func TestUnitEmailAuthIntercept(t *testing.T) {
+	Convey("Email auth intercept", t, func() {
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+
+		Convey("Invalid user details in context", func() {
+			req, _ := http.NewRequestWithContext(invalidTestContext(), "GET", "", nil)
+
+			w := httptest.NewRecorder()
+			test := EmailAuthIntercept(getTestHandler())
+			test.ServeHTTP(w, req)
+			So(w.Code, ShouldEqual, http.StatusInternalServerError)
+		})
+
+		Convey("Error checking EFS allow list", func() {
+			req, _ := http.NewRequestWithContext(testContext(), "GET", "", nil)
+
+			defer httpmock.Reset()
+			httpmock.RegisterResponder(
+				http.MethodGet,
+				"http://localhost:4001/efs-submission-api/company-authentication/allow-list/demo@companieshouse.gov.uk",
+				httpmock.NewStringResponder(http.StatusInternalServerError, ""),
+			)
+
+			w := httptest.NewRecorder()
+			test := EmailAuthIntercept(getTestHandler())
+			test.ServeHTTP(w, req)
+			So(w.Code, ShouldEqual, http.StatusInternalServerError)
+		})
+
+		Convey("User not allowed", func() {
+			req, _ := http.NewRequestWithContext(testContext(), "GET", "", nil)
+
+			defer httpmock.Reset()
+			httpmock.RegisterResponder(
+				http.MethodGet,
+				"http://localhost:4001/efs-submission-api/company-authentication/allow-list/demo@companieshouse.gov.uk?",
+				httpmock.NewStringResponder(http.StatusOK, "false"),
+			)
+
+			w := httptest.NewRecorder()
+			test := EmailAuthIntercept(getTestHandler())
+			test.ServeHTTP(w, req)
+			So(w.Code, ShouldEqual, http.StatusUnauthorized)
+		})
+
+		Convey("User allowed", func() {
+			req, _ := http.NewRequestWithContext(testContext(), "GET", "", nil)
+
+			defer httpmock.Reset()
+			httpmock.RegisterResponder(
+				http.MethodGet,
+				"http://localhost:4001/efs-submission-api/company-authentication/allow-list/demo@companieshouse.gov.uk?",
+				httpmock.NewStringResponder(http.StatusOK, "true"),
+			)
+
+			w := httptest.NewRecorder()
+			test := EmailAuthIntercept(getTestHandler())
+			test.ServeHTTP(w, req)
+			So(w.Code, ShouldEqual, http.StatusOK)
+		})
+	})
+}

--- a/interceptors/email_auth_interceptor_test.go
+++ b/interceptors/email_auth_interceptor_test.go
@@ -100,4 +100,5 @@ func TestUnitEmailAuthIntercept(t *testing.T) {
 			So(w.Code, ShouldEqual, http.StatusOK)
 		})
 	})
-}
+} 
+ 

--- a/interceptors/insolvency_permissions_interceptor_test.go
+++ b/interceptors/insolvency_permissions_interceptor_test.go
@@ -1,0 +1,69 @@
+package interceptors
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/companieshouse/chs.go/authentication"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func setTokenHeader(req *http.Request, permissions string) {
+	req.Header.Set("ERIC-Authorised-Token-Permissions", permissions)
+}
+
+func TestUnitInsolvencyPermissionsIntercept(t *testing.T) {
+	Convey("Insolvency permissions intercept", t, func() {
+
+		Convey("Invalid token header", func() {
+			req, _ := http.NewRequest("GET", "", nil)
+			setTokenHeader(req, "invalid=invalid=invalid")
+
+			w := httptest.NewRecorder()
+
+			test := InsolvencyPermissionsIntercept(getTestHandler())
+			test.ServeHTTP(w, req)
+
+			So(w.Code, ShouldEqual, http.StatusInternalServerError)
+		})
+
+		Convey("Read request", func() {
+			req, _ := http.NewRequest("GET", "", nil)
+			setTokenHeader(req, authentication.PermissionKeyInsolvencyCases+"=read")
+
+			w := httptest.NewRecorder()
+
+			test := InsolvencyPermissionsIntercept(getTestHandler())
+			test.ServeHTTP(w, req)
+
+			So(w.Code, ShouldEqual, http.StatusOK)
+		})
+
+		Convey("Update request", func() {
+			req, _ := http.NewRequest("POST", "", nil)
+			setTokenHeader(req, authentication.PermissionKeyInsolvencyCases+"=update")
+
+			w := httptest.NewRecorder()
+
+			test := InsolvencyPermissionsIntercept(getTestHandler())
+			test.ServeHTTP(w, req)
+
+			So(w.Code, ShouldEqual, http.StatusOK)
+		})
+
+		Convey("Incorrect token permission", func() {
+			req, _ := http.NewRequest("POST", "", nil)
+			setTokenHeader(req, authentication.PermissionKeyInsolvencyCases+"=read")
+
+			w := httptest.NewRecorder()
+
+			test := InsolvencyPermissionsIntercept(getTestHandler())
+			test.ServeHTTP(w, req)
+
+			So(w.Code, ShouldEqual, http.StatusUnauthorized)
+		})
+
+	})
+}

--- a/service/efs_submission_service.go
+++ b/service/efs_submission_service.go
@@ -9,7 +9,7 @@ import (
 
 // IsUserOnEfsAllowList uses the sdk to call the EFS api and return a boolean depending on whether or not the email address is on the allow list
 func IsUserOnEfsAllowList(emailAddress string, req *http.Request) (bool, error) {
-	api, err := manager.GetPrivateSDK(req)
+	api, err := manager.GetInternalSDK(req)
 	if err != nil {
 		return false, fmt.Errorf("error creating SDK to call transaction api: [%v]", err.Error())
 	}


### PR DESCRIPTION
Following merge of changes to SDK Manager: https://github.com/companieshouse/go-sdk-manager/pull/15

There is a new function which allows INTERNAL_API_URL to be passed in as an environment variable to the manager, and in turn to the Private SDK.

Change in this PR is to reflect and use that new function in EFS service to reflect the fact that EFS endpoints are internal.