### PR TITLE
IEP-416: Make premises and post code mandatory in address

### DIFF
--- a/models/request_entities.go
+++ b/models/request_entities.go
@@ -26,7 +26,7 @@ type Address struct {
 	Country      string `json:"country"`
 	Locality     string `json:"locality" validate:"required"`
 	Region       string `json:"region"`
-	PostalCode   string `json:"postal_code"`
+	PostalCode   string `json:"postal_code" validate:"required"`
 	POBox        string `json:"po_box"`
 }
 

--- a/models/request_entities.go
+++ b/models/request_entities.go
@@ -20,7 +20,7 @@ type PractitionerRequest struct {
 
 // Address is the model to represent any addresses within the insolvency service
 type Address struct {
-	Premises     string `json:"premises"`
+	Premises     string `json:"premises" validate:"required"`
 	AddressLine1 string `json:"address_line_1" validate:"required"`
 	AddressLine2 string `json:"address_line_2"`
 	Country      string `json:"country"`


### PR DESCRIPTION
Premises and PO Box were recently added to the API to match the shape of the (already live) ROA API.

However, per IEP-416, premises was intended to be a mandatory field. I have therefore gone and made this minor change to the address model, as well as adding the resulting validation behaviour to the unit tests on the only affected handler: practitioner_resource.

It was also decided recently that postcode should be mandatory, as recorded in the decision log: https://companieshouse.atlassian.net/wiki/spaces/IEP/pages/3481993264/Insolvency+Decision+Log+-+Beta 

Since the change was so similar, I did this under the same ticket.

IEP-416 can be found here:  https://companieshouse.atlassian.net/jira/software/c/projects/IFD/boards/187?modal=detail&selectedIssue=IEP-416

