### PR TITLE
bring LRESEX resolution routes into the enabled handlers

### DIFF
--- a/handlers/register.go
+++ b/handlers/register.go
@@ -50,6 +50,10 @@ func Register(mainRouter *mux.Router, svc dao.Service) {
 	publicAppRouter.Handle("/{transaction_id}/insolvency/attachments/{attachment_id}/download", HandleDownloadAttachment(svc)).Methods(http.MethodGet).Name("downloadAttachment")
 	publicAppRouter.Handle("/{transaction_id}/insolvency/attachments/{attachment_id}", HandleDeleteAttachment(svc)).Methods(http.MethodDelete).Name("deleteAttachment")
 
+	publicAppRouter.Handle("/{transaction_id}/insolvency/resolution", HandleCreateResolution(svc)).Methods(http.MethodPost).Name("createResolution")
+	publicAppRouter.Handle("/{transaction_id}/insolvency/resolution", HandleGetResolution(svc)).Methods(http.MethodGet).Name("getResolution")
+	publicAppRouter.Handle("/{transaction_id}/insolvency/resolution", HandleDeleteResolution(svc)).Methods(http.MethodDelete).Name("deleteResolution")
+
 	// Get environment config - only required whilst feature flag in use to disable
 	// non 600 form handling routes unless set to true
 	cfg, err := config.Get()
@@ -61,10 +65,6 @@ func Register(mainRouter *mux.Router, svc dao.Service) {
 		publicAppRouter.Handle("/{transaction_id}/insolvency/statement-of-affairs", HandleCreateStatementOfAffairs(svc)).Methods(http.MethodPost).Name("createStatementOfAffairs")
 		publicAppRouter.Handle("/{transaction_id}/insolvency/statement-of-affairs", HandleGetStatementOfAffairs(svc)).Methods(http.MethodGet).Name("getStatementOfAffairs")
 		publicAppRouter.Handle("/{transaction_id}/insolvency/statement-of-affairs", HandleDeleteStatementOfAffairs(svc)).Methods(http.MethodDelete).Name("deleteStatementOfAffairs")
-
-		publicAppRouter.Handle("/{transaction_id}/insolvency/resolution", HandleCreateResolution(svc)).Methods(http.MethodPost).Name("createResolution")
-		publicAppRouter.Handle("/{transaction_id}/insolvency/resolution", HandleGetResolution(svc)).Methods(http.MethodGet).Name("getResolution")
-		publicAppRouter.Handle("/{transaction_id}/insolvency/resolution", HandleDeleteResolution(svc)).Methods(http.MethodDelete).Name("deleteResolution")
 	} else {
 		log.Info("LIQ02 endpoints blocked")
 	}

--- a/handlers/register_test.go
+++ b/handlers/register_test.go
@@ -44,13 +44,14 @@ func TestUnitRegisterRoutes(t *testing.T) {
 		So(router.GetRoute("downloadAttachment"), ShouldNotBeNil)
 		So(router.GetRoute("deleteAttachment"), ShouldNotBeNil)
 
+		So(router.GetRoute("createResolution"), ShouldNotBeNil)
+		So(router.GetRoute("getResolution"), ShouldNotBeNil)
+		So(router.GetRoute("deleteResolution"), ShouldNotBeNil)
+
 		So(router.GetRoute("createStatementOfAffairs"), ShouldBeNil)
 		So(router.GetRoute("getStatementOfAffairs"), ShouldBeNil)
 		So(router.GetRoute("deleteStatementOfAffairs"), ShouldBeNil)
 
-		So(router.GetRoute("createResolution"), ShouldBeNil)
-		So(router.GetRoute("getResolution"), ShouldBeNil)
-		So(router.GetRoute("deleteResolution"), ShouldBeNil)
 	})
 
 	// Simulate ENABLE_NON600_ROUTE_HANDLERS feature toggle being enabled


### PR DESCRIPTION
Previously added the LRESEX attachment endpoints as part of the enabled handlers. Now including the LRESEX resolution end points to the enabled handlers list for Insolvency API.