### PR TITLE
iep497 removed case sensitivity on companyname comparison

### DIFF
--- a/service/company_service.go
+++ b/service/company_service.go
@@ -3,6 +3,7 @@ package service
 import (
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/companieshouse/api-sdk-go/companieshouseapi"
 	"github.com/companieshouse/go-sdk-manager/manager"
@@ -66,7 +67,7 @@ func GetCompanyIncorporatedOn(companyNumber string, req *http.Request) (string, 
 func checkCompanyDetailsAreValid(companyProfile *companieshouseapi.CompanyProfile, insolvencyRequest *models.InsolvencyRequest) error {
 
 	// Check company name in request and company profile match
-	if companyProfile.CompanyName != insolvencyRequest.CompanyName {
+	if !strings.EqualFold(companyProfile.CompanyName, insolvencyRequest.CompanyName) {
 		return fmt.Errorf("company names do not match - provided: [%s], expected: [%s]", insolvencyRequest.CompanyName, companyProfile.CompanyName)
 	}
 


### PR DESCRIPTION
code to ignore case when comparing company names in request with company profile.
company names in production are all caps and this will avoid name mismatch.