### PR TITLE
Feature/iep 504 validate companyname with alphakey

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/companieshouse/go-sdk-manager v0.1.12
 	github.com/companieshouse/go-session-handler v0.1.5
 	github.com/companieshouse/gofigure v0.1.4
-	github.com/companieshouse/private-api-sdk-go v0.1.12
+	github.com/companieshouse/private-api-sdk-go v0.1.13
 	github.com/go-playground/locales v0.13.0
 	github.com/go-playground/universal-translator v0.17.0
 	github.com/go-playground/validator/v10 v10.4.1

--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,12 @@ module github.com/companieshouse/insolvency-api
 go 1.16
 
 require (
-	github.com/companieshouse/api-sdk-go v0.1.17
+	github.com/companieshouse/api-sdk-go v0.1.35
 	github.com/companieshouse/chs.go v1.2.6
 	github.com/companieshouse/go-sdk-manager v0.1.12
 	github.com/companieshouse/go-session-handler v0.1.5
 	github.com/companieshouse/gofigure v0.1.4
-	github.com/companieshouse/private-api-sdk-go v0.1.11
+	github.com/companieshouse/private-api-sdk-go v0.1.12
 	github.com/go-playground/locales v0.13.0
 	github.com/go-playground/universal-translator v0.17.0
 	github.com/go-playground/validator/v10 v10.4.1

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/companieshouse/gofigure v0.1.4 h1:BN7Dqn0xvNHwC+KHOUHigwP7ajkfHORos3h
 github.com/companieshouse/gofigure v0.1.4/go.mod h1:lBAsI13q21rMce+pO7x4xUYAXzO0MchuDsZUbCs0Yng=
 github.com/companieshouse/htmlform v0.1.0/go.mod h1:fWScPVYjGyeBhYwppGaGRDtCQ5hMd3t3Q+0I6HaUZT4=
 github.com/companieshouse/private-api-sdk-go v0.1.11/go.mod h1:EaRgxVpcHv6IZ1LKp2xqE4rdEsQwgYqVz3g/BIHQVD4=
-github.com/companieshouse/private-api-sdk-go v0.1.12 h1:lyWDAhyUGD5pXObbA7ICRWEMrhyRthnXMg2WM7MAWT4=
-github.com/companieshouse/private-api-sdk-go v0.1.12/go.mod h1:g1zvBCn8Tyc45x+5BmlHsq+BYwuekd5FLRaFOqTUu+A=
+github.com/companieshouse/private-api-sdk-go v0.1.13 h1:o9PD1aSVu3+tbf/WUZT/wX1e0DNx+9xcJugbqo7rbxE=
+github.com/companieshouse/private-api-sdk-go v0.1.13/go.mod h1:g1zvBCn8Tyc45x+5BmlHsq+BYwuekd5FLRaFOqTUu+A=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,9 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/DataDog/zstd v1.3.6-0.20190409195224-796139022798/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
 github.com/Shopify/sarama v1.23.1/go.mod h1:XLH1GYJnLVE0XCr6KdJGVJRTwY30moWNJ4sERjXX6fs=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
-github.com/companieshouse/api-sdk-go v0.1.17 h1:zwZEbWYGJTkgOpopbzE+6TSkWZ5XIbNysj0izmdjuXM=
 github.com/companieshouse/api-sdk-go v0.1.17/go.mod h1:y7Mly0M9Jfgq/hhlWNodyWI9FcpoMZUVClS+AyaT6xY=
+github.com/companieshouse/api-sdk-go v0.1.35 h1:jMbnPxfzwovVByoVHea0pB/KAE96F3IEWz7wI2vZg5k=
+github.com/companieshouse/api-sdk-go v0.1.35/go.mod h1:y7Mly0M9Jfgq/hhlWNodyWI9FcpoMZUVClS+AyaT6xY=
 github.com/companieshouse/chs.go v1.1.0/go.mod h1:LVtty6/5ttvNf12V/nPySaIFgfYPLeT0jymabuzmSDg=
 github.com/companieshouse/chs.go v1.2.2/go.mod h1:93vQ2qlzSbZenUOFet+pAJzxHdz+w6BF1IvJ56lvC7c=
 github.com/companieshouse/chs.go v1.2.6 h1:q5W8JPUDIDBrwiRYl5UefnWK14x4aTC+ZysYyrge//8=
@@ -20,8 +21,9 @@ github.com/companieshouse/gofigure v0.1.0/go.mod h1:W7NZ4kQdDXqvqK1f7EKTc+pnnqpF
 github.com/companieshouse/gofigure v0.1.4 h1:BN7Dqn0xvNHwC+KHOUHigwP7ajkfHORos3hKRtEACUU=
 github.com/companieshouse/gofigure v0.1.4/go.mod h1:lBAsI13q21rMce+pO7x4xUYAXzO0MchuDsZUbCs0Yng=
 github.com/companieshouse/htmlform v0.1.0/go.mod h1:fWScPVYjGyeBhYwppGaGRDtCQ5hMd3t3Q+0I6HaUZT4=
-github.com/companieshouse/private-api-sdk-go v0.1.11 h1:MrD1syupeBmtJlKmwe+qWlXapLMjZBYSFQau1YHVPFk=
 github.com/companieshouse/private-api-sdk-go v0.1.11/go.mod h1:EaRgxVpcHv6IZ1LKp2xqE4rdEsQwgYqVz3g/BIHQVD4=
+github.com/companieshouse/private-api-sdk-go v0.1.12 h1:lyWDAhyUGD5pXObbA7ICRWEMrhyRthnXMg2WM7MAWT4=
+github.com/companieshouse/private-api-sdk-go v0.1.12/go.mod h1:g1zvBCn8Tyc45x+5BmlHsq+BYwuekd5FLRaFOqTUu+A=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/handlers/insolvency_resource.go
+++ b/handlers/insolvency_resource.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/companieshouse/api-sdk-go/companieshouseapi"
 	"github.com/companieshouse/chs.go/log"
 	"github.com/companieshouse/insolvency-api/constants"
 	"github.com/companieshouse/insolvency-api/dao"
@@ -69,13 +70,31 @@ func HandleCreateInsolvencyResource(svc dao.Service) http.Handler {
 			return
 		}
 
-		// Check with company profile API if company is valid
-		err, httpStatus = service.CheckCompanyInsolvencyValid(&request, req)
+		// Check with company profile API if company exists
+		var companyProfile *companieshouseapi.CompanyProfile
+		err, httpStatus, companyProfile = service.CheckCompanyExists(&request, req)
 		if err != nil {
 			log.ErrorR(req, fmt.Errorf("company was not found valid when checking company profile API [%v]", err))
 			m := models.NewMessageResponse(fmt.Sprintf("company [%s] was not found valid for insolvency: %v", request.CompanyNumber, err))
 			utils.WriteJSONWithStatus(w, req, m, httpStatus)
 			return
+		}
+
+		//Check with alphakey service if company name valid and Check with company profile API if other details are valid
+		err, httpStatus = service.CheckCompanyNameAlphaKey(companyProfile.CompanyName, &request, req)
+		if err != nil {
+			log.ErrorR(req, fmt.Errorf("company name was not found valid when checking company profile API [%v]", err))
+			m := models.NewMessageResponse(fmt.Sprintf("company name [%s] was not found valid for insolvency: %v", request.CompanyNumber, err))
+			utils.WriteJSONWithStatus(w, req, m, httpStatus)
+			return
+		} else {
+			err = service.CheckCompanyDetailsAreValid(companyProfile, &request)
+			if err != nil {
+				log.ErrorR(req, fmt.Errorf("company was not found valid when checking company profile API [%v]", err))
+				m := models.NewMessageResponse(fmt.Sprintf("company [%s] was not found valid for insolvency: %v", request.CompanyNumber, err))
+				utils.WriteJSONWithStatus(w, req, m, http.StatusBadRequest)
+				return
+			}
 		}
 
 		// Add new insolvency resource to mongo

--- a/handlers/insolvency_resource.go
+++ b/handlers/insolvency_resource.go
@@ -80,22 +80,24 @@ func HandleCreateInsolvencyResource(svc dao.Service) http.Handler {
 			return
 		}
 
-		//Check with alphakey service if company name valid and Check with company profile API if other details are valid
+		// Check with alphakey service if company name valid
 		err, httpStatus = service.CheckCompanyNameAlphaKey(companyProfile.CompanyName, &request, req)
 		if err != nil {
 			log.ErrorR(req, fmt.Errorf("company name was not found valid when checking company profile API [%v]", err))
 			m := models.NewMessageResponse(fmt.Sprintf("company name [%s] was not found valid for insolvency: %v", request.CompanyNumber, err))
 			utils.WriteJSONWithStatus(w, req, m, httpStatus)
 			return
-		} else {
-			err = service.CheckCompanyDetailsAreValid(companyProfile, &request)
-			if err != nil {
-				log.ErrorR(req, fmt.Errorf("company was not found valid when checking company profile API [%v]", err))
-				m := models.NewMessageResponse(fmt.Sprintf("company [%s] was not found valid for insolvency: %v", request.CompanyNumber, err))
-				utils.WriteJSONWithStatus(w, req, m, http.StatusBadRequest)
-				return
-			}
+		} 
+		
+		// Check with company profile API if other details are valid
+		err = service.CheckCompanyDetailsAreValid(companyProfile)
+		if err != nil {
+			log.ErrorR(req, fmt.Errorf("company was not found valid when checking company profile API [%v]", err))
+			m := models.NewMessageResponse(fmt.Sprintf("company [%s] was not found valid for insolvency: %v", request.CompanyNumber, err))
+			utils.WriteJSONWithStatus(w, req, m, http.StatusBadRequest)
+			return
 		}
+		
 
 		// Add new insolvency resource to mongo
 		model := transformers.InsolvencyResourceRequestToDB(&request, transactionID)

--- a/handlers/insolvency_resource_test.go
+++ b/handlers/insolvency_resource_test.go
@@ -178,7 +178,7 @@ func TestUnitHandleCreateInsolvencyResource(t *testing.T) {
 
 		// Expect the alphakeyservice api to be called and return an alphakey
 		httpmock.RegisterResponder(http.MethodGet, "http://localhost:4001/alphakey?name=companyName", httpmock.NewStringResponder(http.StatusOK, alphakeyResponse))
-		
+
 		mockService := mock_dao.NewMockService(mockCtrl)
 
 		body, _ := json.Marshal(&models.InsolvencyRequest{
@@ -274,7 +274,7 @@ func TestUnitHandleCreateInsolvencyResource(t *testing.T) {
 
 		// Expect the alphakeyservice api to be called and return an alphakey
 		httpmock.RegisterResponder(http.MethodGet, "http://localhost:4001/alphakey?name=companyName", httpmock.NewStringResponder(http.StatusOK, alphakeyResponse))
-		
+
 		mockService := mock_dao.NewMockService(mockCtrl)
 		// Expect CreateInsolvencyResource to be called once and return an error
 		mockService.EXPECT().CreateInsolvencyResource(gomock.Any()).Return(errors.New("insolvency case already exists"), http.StatusConflict).Times(1)
@@ -303,7 +303,7 @@ func TestUnitHandleCreateInsolvencyResource(t *testing.T) {
 
 		// Expect the alphakeyservice api to be called and return an alphakey
 		httpmock.RegisterResponder(http.MethodGet, "http://localhost:4001/alphakey?name=companyName", httpmock.NewStringResponder(http.StatusOK, alphakeyResponse))
-		
+
 		mockService := mock_dao.NewMockService(mockCtrl)
 		// Expect CreateInsolvencyResource to be called once and return an error
 		mockService.EXPECT().CreateInsolvencyResource(gomock.Any()).Return(errors.New("error when creating mongo resource"), http.StatusInternalServerError).Times(1)
@@ -332,7 +332,7 @@ func TestUnitHandleCreateInsolvencyResource(t *testing.T) {
 
 		// Expect the alphakeyservice api to be called and return an alphakey
 		httpmock.RegisterResponder(http.MethodGet, "http://localhost:4001/alphakey?name=companyName", httpmock.NewStringResponder(http.StatusOK, alphakeyResponse))
-		
+
 		// Expect the transaction api to be patched and return a success
 		httpmock.RegisterResponder(http.MethodPatch, "http://localhost:4001/private/transactions/12345678", httpmock.NewStringResponder(http.StatusInternalServerError, transactionProfileResponse))
 
@@ -364,7 +364,7 @@ func TestUnitHandleCreateInsolvencyResource(t *testing.T) {
 
 		// Expect the alphakeyservice api to be called and return an alphakey
 		httpmock.RegisterResponder(http.MethodGet, "http://localhost:4001/alphakey?name=companyName", httpmock.NewStringResponder(http.StatusOK, alphakeyResponse))
-		
+
 		// Expect the transaction api to be patched and return a success
 		httpmock.RegisterResponder(http.MethodPatch, "http://localhost:4001/private/transactions/12345678", httpmock.NewStringResponder(http.StatusNotFound, ""))
 
@@ -396,7 +396,7 @@ func TestUnitHandleCreateInsolvencyResource(t *testing.T) {
 
 		// Expect the alphakeyservice api to be called and return an alphakey
 		httpmock.RegisterResponder(http.MethodGet, "http://localhost:4001/alphakey?name=companyName", httpmock.NewStringResponder(http.StatusOK, alphakeyResponse))
-		
+
 		// Expect the transaction api to be patched and return a success
 		httpmock.RegisterResponder(http.MethodPatch, "http://localhost:4001/private/transactions/12345678", httpmock.NewStringResponder(http.StatusNoContent, transactionProfileResponse))
 

--- a/handlers/insolvency_resource_test.go
+++ b/handlers/insolvency_resource_test.go
@@ -59,6 +59,13 @@ var transactionProfileResponseClosed = `
  "status": "closed"
 }
 `
+var alphakeyResponse = `
+{
+	"sameAsAlphaKey": "COMPANYNAME",
+	"orderedAlphaKey": "COMPANYNAME",
+	"upperCaseName": "COMPANYNAME"
+}
+`
 
 func serveHandleCreateInsolvencyResource(body []byte, service dao.Service, tranIDSet bool) *httptest.ResponseRecorder {
 
@@ -169,6 +176,9 @@ func TestUnitHandleCreateInsolvencyResource(t *testing.T) {
 		// Expect the transaction api to be called and return a valid transaction
 		httpmock.RegisterResponder(http.MethodGet, "https://api.companieshouse.gov.uk/transactions/12345678", httpmock.NewStringResponder(http.StatusInternalServerError, ""))
 
+		// Expect the alphakeyservice api to be called and return an alphakey
+		httpmock.RegisterResponder(http.MethodGet, "http://localhost:4001/alphakey?name=companyName", httpmock.NewStringResponder(http.StatusOK, alphakeyResponse))
+		
 		mockService := mock_dao.NewMockService(mockCtrl)
 
 		body, _ := json.Marshal(&models.InsolvencyRequest{
@@ -262,6 +272,9 @@ func TestUnitHandleCreateInsolvencyResource(t *testing.T) {
 		// Expect the company profile api to be called and return a valid company
 		httpmock.RegisterResponder(http.MethodGet, "https://api.companieshouse.gov.uk/company/01234567", httpmock.NewStringResponder(http.StatusOK, companyProfileResponse))
 
+		// Expect the alphakeyservice api to be called and return an alphakey
+		httpmock.RegisterResponder(http.MethodGet, "http://localhost:4001/alphakey?name=companyName", httpmock.NewStringResponder(http.StatusOK, alphakeyResponse))
+		
 		mockService := mock_dao.NewMockService(mockCtrl)
 		// Expect CreateInsolvencyResource to be called once and return an error
 		mockService.EXPECT().CreateInsolvencyResource(gomock.Any()).Return(errors.New("insolvency case already exists"), http.StatusConflict).Times(1)
@@ -288,6 +301,9 @@ func TestUnitHandleCreateInsolvencyResource(t *testing.T) {
 		// Expect the company profile api to be called and return a valid company
 		httpmock.RegisterResponder(http.MethodGet, "https://api.companieshouse.gov.uk/company/01234567", httpmock.NewStringResponder(http.StatusOK, companyProfileResponse))
 
+		// Expect the alphakeyservice api to be called and return an alphakey
+		httpmock.RegisterResponder(http.MethodGet, "http://localhost:4001/alphakey?name=companyName", httpmock.NewStringResponder(http.StatusOK, alphakeyResponse))
+		
 		mockService := mock_dao.NewMockService(mockCtrl)
 		// Expect CreateInsolvencyResource to be called once and return an error
 		mockService.EXPECT().CreateInsolvencyResource(gomock.Any()).Return(errors.New("error when creating mongo resource"), http.StatusInternalServerError).Times(1)
@@ -314,6 +330,9 @@ func TestUnitHandleCreateInsolvencyResource(t *testing.T) {
 		// Expect the company profile api to be called and return a valid company
 		httpmock.RegisterResponder(http.MethodGet, "https://api.companieshouse.gov.uk/company/01234567", httpmock.NewStringResponder(http.StatusOK, companyProfileResponse))
 
+		// Expect the alphakeyservice api to be called and return an alphakey
+		httpmock.RegisterResponder(http.MethodGet, "http://localhost:4001/alphakey?name=companyName", httpmock.NewStringResponder(http.StatusOK, alphakeyResponse))
+		
 		// Expect the transaction api to be patched and return a success
 		httpmock.RegisterResponder(http.MethodPatch, "http://localhost:4001/private/transactions/12345678", httpmock.NewStringResponder(http.StatusInternalServerError, transactionProfileResponse))
 
@@ -343,6 +362,9 @@ func TestUnitHandleCreateInsolvencyResource(t *testing.T) {
 		// Expect the company profile api to be called and return a valid company
 		httpmock.RegisterResponder(http.MethodGet, "https://api.companieshouse.gov.uk/company/01234567", httpmock.NewStringResponder(http.StatusOK, companyProfileResponse))
 
+		// Expect the alphakeyservice api to be called and return an alphakey
+		httpmock.RegisterResponder(http.MethodGet, "http://localhost:4001/alphakey?name=companyName", httpmock.NewStringResponder(http.StatusOK, alphakeyResponse))
+		
 		// Expect the transaction api to be patched and return a success
 		httpmock.RegisterResponder(http.MethodPatch, "http://localhost:4001/private/transactions/12345678", httpmock.NewStringResponder(http.StatusNotFound, ""))
 
@@ -372,6 +394,9 @@ func TestUnitHandleCreateInsolvencyResource(t *testing.T) {
 		// Expect the company profile api to be called and return a valid company
 		httpmock.RegisterResponder(http.MethodGet, "https://api.companieshouse.gov.uk/company/01234567", httpmock.NewStringResponder(http.StatusOK, companyProfileResponse))
 
+		// Expect the alphakeyservice api to be called and return an alphakey
+		httpmock.RegisterResponder(http.MethodGet, "http://localhost:4001/alphakey?name=companyName", httpmock.NewStringResponder(http.StatusOK, alphakeyResponse))
+		
 		// Expect the transaction api to be patched and return a success
 		httpmock.RegisterResponder(http.MethodPatch, "http://localhost:4001/private/transactions/12345678", httpmock.NewStringResponder(http.StatusNoContent, transactionProfileResponse))
 

--- a/interceptors/email_auth_interceptor_test.go
+++ b/interceptors/email_auth_interceptor_test.go
@@ -100,5 +100,4 @@ func TestUnitEmailAuthIntercept(t *testing.T) {
 			So(w.Code, ShouldEqual, http.StatusOK)
 		})
 	})
-} 
- 
+}

--- a/service/alpha_key_service.go
+++ b/service/alpha_key_service.go
@@ -10,14 +10,15 @@ import (
 	"strings"
 )
 
-func checkCompanyNameAlphaKey(companyProfileCompanyName string, insolvencyRequest *models.InsolvencyRequest, req *http.Request, ) (error, int) {
-	
+func CheckCompanyNameAlphaKey(companyProfileCompanyName string, insolvencyRequest *models.InsolvencyRequest, req *http.Request) (error, int) {
+
 	api, err := manager.GetPrivateSDK(req)
 	if err != nil {
 		return fmt.Errorf("error creating private SDK to call alphakeyservice: [%v]", err.Error()), http.StatusInternalServerError
 	}
-	
-	
+
+	log.Info("AAAAPIIII", log.Data{"api": api})
+
 	requestAlphaKeyResponse, err := api.AlphaKey.Get(insolvencyRequest.CompanyName).Do()
 	if err != nil {
 		log.ErrorR(req, fmt.Errorf("error communicating with alphakey service [%v]", err))
@@ -41,4 +42,3 @@ func checkCompanyNameAlphaKey(companyProfileCompanyName string, insolvencyReques
 	//no error
 	return nil, requestAlphaKeyResponse.HTTPStatusCode
 }
-

--- a/service/alpha_key_service.go
+++ b/service/alpha_key_service.go
@@ -1,0 +1,44 @@
+package service
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/companieshouse/chs.go/log"
+	"github.com/companieshouse/go-sdk-manager/manager"
+	"github.com/companieshouse/insolvency-api/models"
+	"strings"
+)
+
+func checkCompanyNameAlphaKey(companyProfileCompanyName string, insolvencyRequest *models.InsolvencyRequest, req *http.Request, ) (error, int) {
+	
+	api, err := manager.GetPrivateSDK(req)
+	if err != nil {
+		return fmt.Errorf("error creating private SDK to call alphakeyservice: [%v]", err.Error()), http.StatusInternalServerError
+	}
+	
+	
+	requestAlphaKeyResponse, err := api.AlphaKey.Get(insolvencyRequest.CompanyName).Do()
+	if err != nil {
+		log.ErrorR(req, fmt.Errorf("error communicating with alphakey service [%v]", err))
+		return fmt.Errorf("error verifying company name"), requestAlphaKeyResponse.HTTPStatusCode
+	}
+
+	insolvencyRequestAlphaKey := requestAlphaKeyResponse.SameAsAlphaKey
+
+	profileAlphaKeyResponse, err := api.AlphaKey.Get(companyProfileCompanyName).Do()
+	if err != nil {
+		log.ErrorR(req, fmt.Errorf("error communicating with alphakey service [%v]", err))
+		return fmt.Errorf("error verifying company name"), requestAlphaKeyResponse.HTTPStatusCode
+	}
+
+	profileAlphaKey := profileAlphaKeyResponse.SameAsAlphaKey
+
+	if !strings.EqualFold(insolvencyRequestAlphaKey, profileAlphaKey) {
+		return fmt.Errorf("company names do not match - provided: [%s], expected: [%s]", insolvencyRequest.CompanyName, companyProfileCompanyName), http.StatusBadRequest
+	}
+
+	//no error
+	return nil, requestAlphaKeyResponse.HTTPStatusCode
+}
+

--- a/service/alpha_key_service.go
+++ b/service/alpha_key_service.go
@@ -17,8 +17,6 @@ func CheckCompanyNameAlphaKey(companyProfileCompanyName string, insolvencyReques
 		return fmt.Errorf("error creating private SDK to call alphakeyservice: [%v]", err.Error()), http.StatusInternalServerError
 	}
 
-	log.Info("AAAAPIIII", log.Data{"api": api})
-
 	requestAlphaKeyResponse, err := api.AlphaKey.Get(insolvencyRequest.CompanyName).Do()
 	if err != nil {
 		log.ErrorR(req, fmt.Errorf("error communicating with alphakey service [%v]", err))

--- a/service/alpha_key_service.go
+++ b/service/alpha_key_service.go
@@ -20,7 +20,7 @@ func CheckCompanyNameAlphaKey(companyProfileCompanyName string, insolvencyReques
 	requestAlphaKeyResponse, err := api.AlphaKey.Get(insolvencyRequest.CompanyName).Do()
 	if err != nil {
 		log.ErrorR(req, fmt.Errorf("error communicating with alphakey service [%v]", err))
-		return fmt.Errorf("error verifying company name"), requestAlphaKeyResponse.HTTPStatusCode
+		return fmt.Errorf("error communicating with alphakey service"), requestAlphaKeyResponse.HTTPStatusCode
 	}
 
 	insolvencyRequestAlphaKey := requestAlphaKeyResponse.SameAsAlphaKey
@@ -28,7 +28,7 @@ func CheckCompanyNameAlphaKey(companyProfileCompanyName string, insolvencyReques
 	profileAlphaKeyResponse, err := api.AlphaKey.Get(companyProfileCompanyName).Do()
 	if err != nil {
 		log.ErrorR(req, fmt.Errorf("error communicating with alphakey service [%v]", err))
-		return fmt.Errorf("error verifying company name"), requestAlphaKeyResponse.HTTPStatusCode
+		return fmt.Errorf("error communicating with alphakey service"), requestAlphaKeyResponse.HTTPStatusCode
 	}
 
 	profileAlphaKey := profileAlphaKeyResponse.SameAsAlphaKey
@@ -37,6 +37,5 @@ func CheckCompanyNameAlphaKey(companyProfileCompanyName string, insolvencyReques
 		return fmt.Errorf("company names do not match - provided: [%s], expected: [%s]", insolvencyRequest.CompanyName, companyProfileCompanyName), http.StatusBadRequest
 	}
 
-	//no error
 	return nil, requestAlphaKeyResponse.HTTPStatusCode
 }

--- a/service/alpha_key_service_test.go
+++ b/service/alpha_key_service_test.go
@@ -49,14 +49,13 @@ func TestUnitCheckCompanyNameValid(t *testing.T) {
 
 		Convey("Error contacting the alpha key service api", func() {
 			defer httpmock.Reset()
-			req, _ := http.NewRequest("GET", "", nil)
-			httpmock.RegisterResponder(http.MethodGet, "http://localhost:4001/alphakey/name=companyName", httpmock.NewStringResponder(http.StatusInternalServerError, ""))
+			httpmock.RegisterResponder(http.MethodGet, "http://localhost:4001/alphakey?name=companyName", httpmock.NewStringResponder(http.StatusInternalServerError, ""))
 
 			request := incomingInsolvencyRequest("01234567", "companyName", constants.CVL.String())
-			err, statusCode := CheckCompanyNameAlphaKey("companyName", request, req)
+			err, statusCode := CheckCompanyNameAlphaKey("companyName", request, &http.Request{})
 			So(err, ShouldNotBeNil)
 			So(statusCode, ShouldEqual, http.StatusInternalServerError)
-			So(err.Error(), ShouldEqual, `error communicating with the company profile api`)
+			So(err.Error(), ShouldContainSubstring, `error communicating with alphakey service`)
 		})
 	})
 }

--- a/service/alpha_key_service_test.go
+++ b/service/alpha_key_service_test.go
@@ -1,10 +1,10 @@
 package service
 
 import (
+	"github.com/companieshouse/insolvency-api/constants"
 	"net/http"
 	"testing"
 
-	"github.com/companieshouse/insolvency-api/constants"
 	"github.com/jarcoal/httpmock"
 	. "github.com/smartystreets/goconvey/convey"
 )
@@ -23,28 +23,40 @@ func TestUnitCheckCompanyNameValid(t *testing.T) {
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
 
-		httpmock.RegisterResponder(http.MethodGet, "http://localhost:4001/alphakey?name=companyName", httpmock.NewStringResponder(http.StatusOK, alphaKeyResponse("COMPANYNAME")))
-		httpmock.RegisterResponder(http.MethodGet, "http://localhost:4001/alphakey?name=COMPANYNAME", httpmock.NewStringResponder(http.StatusOK, alphaKeyResponse("COMPANYNAME")))
+		Convey("Company name matches with company profile by alphaley", func() {
+			httpmock.RegisterResponder(http.MethodGet, "http://localhost:4001/alphakey?name=companyName", httpmock.NewStringResponder(http.StatusOK, alphaKeyResponse("COMPANYNAME")))
+			httpmock.RegisterResponder(http.MethodGet, "http://localhost:4001/alphakey?name=COMPANYNAME", httpmock.NewStringResponder(http.StatusOK, alphaKeyResponse("COMPANYNAME")))
 
-		request := incomingInsolvencyRequest("01234567", "companyName", constants.CVL.String())
-		err, statusCode := CheckCompanyNameAlphaKey("COMPANYNAME", request, &http.Request{})
-		So(err, ShouldBeNil)
-		So(statusCode, ShouldEqual, http.StatusOK)
+			request := incomingInsolvencyRequest("01234567", "companyName", constants.CVL.String())
+			err, statusCode := CheckCompanyNameAlphaKey("COMPANYNAME", request, &http.Request{})
+			So(err, ShouldBeNil)
+			So(statusCode, ShouldEqual, http.StatusOK)
 
-	})
+		})
 
-	Convey("CheckCompanyInsolvencyInValidFromAlphaKeyServiceAPI", t, func() {
-		httpmock.Activate()
-		defer httpmock.DeactivateAndReset()
+		Convey("Company name does not match with company profile by alphaley", func() {
 
-		httpmock.RegisterResponder(http.MethodGet, "http://localhost:4001/alphakey?name=companyName", httpmock.NewStringResponder(http.StatusOK, alphaKeyResponse("COMPANYNAME")))
-		httpmock.RegisterResponder(http.MethodGet, "http://localhost:4001/alphakey?name=ANOTHERNAME", httpmock.NewStringResponder(http.StatusOK, alphaKeyResponse("ANOTHERNAME")))
+			httpmock.RegisterResponder(http.MethodGet, "http://localhost:4001/alphakey?name=companyName", httpmock.NewStringResponder(http.StatusOK, alphaKeyResponse("COMPANYNAME")))
+			httpmock.RegisterResponder(http.MethodGet, "http://localhost:4001/alphakey?name=ANOTHERNAME", httpmock.NewStringResponder(http.StatusOK, alphaKeyResponse("ANOTHERNAME")))
 
-		request := incomingInsolvencyRequest("01234567", "companyName", constants.CVL.String())
-		err, statusCode := CheckCompanyNameAlphaKey("ANOTHERNAME", request, &http.Request{})
-		So(err, ShouldNotBeNil)
-		So(err.Error(), ShouldContainSubstring, "company names do not match")
-		So(statusCode, ShouldEqual, http.StatusBadRequest)
+			request := incomingInsolvencyRequest("01234567", "companyName", constants.CVL.String())
+			err, statusCode := CheckCompanyNameAlphaKey("ANOTHERNAME", request, &http.Request{})
+			So(err, ShouldNotBeNil)
+			So(err.Error(), ShouldContainSubstring, "company names do not match")
+			So(statusCode, ShouldEqual, http.StatusBadRequest)
 
+		})
+
+		Convey("Error contacting the alpha key service api", func() {
+			defer httpmock.Reset()
+			req, _ := http.NewRequest("GET", "", nil)
+			httpmock.RegisterResponder(http.MethodGet, "http://localhost:4001/alphakey/name=companyName", httpmock.NewStringResponder(http.StatusInternalServerError, ""))
+
+			request := incomingInsolvencyRequest("01234567", "companyName", constants.CVL.String())
+			err, statusCode := CheckCompanyNameAlphaKey("companyName", request, req)
+			So(err, ShouldNotBeNil)
+			So(statusCode, ShouldEqual, http.StatusInternalServerError)
+			So(err.Error(), ShouldEqual, `error communicating with the company profile api`)
+		})
 	})
 }

--- a/service/alpha_key_service_test.go
+++ b/service/alpha_key_service_test.go
@@ -1,0 +1,50 @@
+package service
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/companieshouse/insolvency-api/constants"
+	"github.com/jarcoal/httpmock"
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func alphaKeyResponse(companyName string) string {
+	return `
+	{
+		"sameAsAlphaKey": " ` + companyName + `",
+		"orderedAlphaKey": "COMPANYNAME",
+		"upperCaseName": "COMPANYNAME"
+	}`
+}
+func TestUnitCheckCompanyNameValid(t *testing.T) {
+
+	Convey("CheckCompanyInsolvencyValidFromAlphaKeyServiceAPI", t, func() {
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+
+		httpmock.RegisterResponder(http.MethodGet, "http://localhost:4001/alphakey?name=companyName", httpmock.NewStringResponder(http.StatusOK, alphaKeyResponse("COMPANYNAME")))
+		httpmock.RegisterResponder(http.MethodGet, "http://localhost:4001/alphakey?name=COMPANYNAME", httpmock.NewStringResponder(http.StatusOK, alphaKeyResponse("COMPANYNAME")))
+
+		request := incomingInsolvencyRequest("01234567", "companyName", constants.CVL.String())
+		err, statusCode := CheckCompanyNameAlphaKey("COMPANYNAME", request, &http.Request{})
+		So(err, ShouldBeNil)
+		So(statusCode, ShouldEqual, http.StatusOK)
+
+	})
+
+	Convey("CheckCompanyInsolvencyInValidFromAlphaKeyServiceAPI", t, func() {
+		httpmock.Activate()
+		defer httpmock.DeactivateAndReset()
+
+		httpmock.RegisterResponder(http.MethodGet, "http://localhost:4001/alphakey?name=companyName", httpmock.NewStringResponder(http.StatusOK, alphaKeyResponse("COMPANYNAME")))
+		httpmock.RegisterResponder(http.MethodGet, "http://localhost:4001/alphakey?name=ANOTHERNAME", httpmock.NewStringResponder(http.StatusOK, alphaKeyResponse("ANOTHERNAME")))
+
+		request := incomingInsolvencyRequest("01234567", "companyName", constants.CVL.String())
+		err, statusCode := CheckCompanyNameAlphaKey("ANOTHERNAME", request, &http.Request{})
+		So(err, ShouldNotBeNil)
+		So(err.Error(), ShouldContainSubstring, "company names do not match")
+		So(statusCode, ShouldEqual, http.StatusBadRequest)
+
+	})
+}

--- a/service/company_service.go
+++ b/service/company_service.go
@@ -57,8 +57,8 @@ func GetCompanyIncorporatedOn(companyNumber string, req *http.Request) (string, 
 	return companyProfile.DateOfCreation, nil
 }
 
-// checkCompanyDetailsAreValid checks the incoming company profile to see if it's valid for insolvency
-func CheckCompanyDetailsAreValid(companyProfile *companieshouseapi.CompanyProfile, insolvencyRequest *models.InsolvencyRequest) error {
+// CheckCompanyDetailsAreValid checks the incoming company profile to see if it's valid for insolvency
+func CheckCompanyDetailsAreValid(companyProfile *companieshouseapi.CompanyProfile) error {
 
 	// Check if company jurisdiction is allowed
 	if !checkJurisdictionIsAllowed(companyProfile.Jurisdiction) {

--- a/service/company_service_test.go
+++ b/service/company_service_test.go
@@ -128,9 +128,28 @@ func TestUnitCheckCompanyInsolvencyValid(t *testing.T) {
 		})
 
 		Convey("Company is allowed to start insolvency case", func() {
+
+			alphakeyResponse := `{
+					"sameAsAlphaKey": "COMPANYNAME",
+					"orderedAlphaKey": "COMPANYNAME",
+					"upperCaseName": "COMPANYNAME"
+				}`
+
 			defer httpmock.Reset()
 			httpmock.RegisterResponder(http.MethodGet, apiURL+"/company/01234567", httpmock.NewStringResponder(http.StatusOK,
 				companyProfileResponse("england-wales", "active", "private-shares-exemption-30")))
+
+			httpmock.RegisterResponder(
+				http.MethodGet,
+				"http://localhost:4001/alphakey?name=companyName",
+				httpmock.NewStringResponder(http.StatusOK, alphakeyResponse),
+				)
+
+			httpmock.RegisterResponder(
+				http.MethodGet,
+				"http://localhost:4001/alphakey?name=COMPANYNAME",
+				httpmock.NewStringResponder(http.StatusOK, alphakeyResponse),
+			)
 
 			request := incomingInsolvencyRequest("01234567", "companyName", constants.CVL.String())
 			err, statusCode := CheckCompanyInsolvencyValid(request, &http.Request{})

--- a/service/company_service_test.go
+++ b/service/company_service_test.go
@@ -73,37 +73,34 @@ func TestUnitCheckCompanyInsolvencyValid(t *testing.T) {
 
 		Convey("Jurisdiction of company is not allowed to create insolvency case", func() {
 
-			var companyProfile *companieshouseapi.CompanyProfile
+			// var companyProfile *companieshouseapi.CompanyProfile
 			json.Unmarshal([]byte(companyProfileResponse("scotland", "active", "private-shares-exemption-30")), &companyProfile)
 
-			request := incomingInsolvencyRequest("01234567", "companyName", constants.CVL.String())
-			err := CheckCompanyDetailsAreValid(companyProfile, request)
+			err := CheckCompanyDetailsAreValid(companyProfile)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldEqual, `jurisdiction [scotland] not permitted`)
 		})
 
 		Convey("Company status is not allowed to create insolvency case", func() {
 			json.Unmarshal([]byte(companyProfileResponse("england-wales", "dissolved", "private-shares-exemption-30")), &companyProfile)
-			request := incomingInsolvencyRequest("01234567", "companyName", constants.CVL.String())
-			// err, statusCode := CheckCompanyInsolvencyValid(request, &http.Request{})
-			err := CheckCompanyDetailsAreValid(companyProfile, request)
+			
+			err := CheckCompanyDetailsAreValid(companyProfile)
 			So(err, ShouldNotBeNil)
-			// So(statusCode, ShouldEqual, http.StatusBadRequest)
 			So(err.Error(), ShouldEqual, `company status [dissolved] not permitted`)
 		})
 
 		Convey("Company type is not allowed to create insolvency case", func() {
 			json.Unmarshal([]byte(companyProfileResponse("england-wales", "active", "converted-or-closed")), &companyProfile)
-			request := incomingInsolvencyRequest("01234567", "companyName", constants.CVL.String())
-			err := CheckCompanyDetailsAreValid(companyProfile, request)
+			
+			err := CheckCompanyDetailsAreValid(companyProfile)
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldEqual, `company type [converted-or-closed] not permitted`)
 		})
 
 		Convey("Company is allowed to start insolvency case", func() {
 			json.Unmarshal([]byte(companyProfileResponse("england-wales", "active", "private-shares-exemption-30")), &companyProfile)
-			request := incomingInsolvencyRequest("01234567", "companyName", constants.CVL.String())
-			err := CheckCompanyDetailsAreValid(companyProfile, request)
+			
+			err := CheckCompanyDetailsAreValid(companyProfile)
 			So(err, ShouldBeNil)
 		})
 	})

--- a/service/company_service_test.go
+++ b/service/company_service_test.go
@@ -1,9 +1,11 @@
 package service
 
 import (
+	"encoding/json"
 	"net/http"
 	"testing"
 
+	"github.com/companieshouse/api-sdk-go/companieshouseapi"
 	"github.com/companieshouse/insolvency-api/constants"
 	"github.com/companieshouse/insolvency-api/models"
 	"github.com/jarcoal/httpmock"
@@ -34,7 +36,6 @@ func companyProfileResponse(jurisdiction string, companyStatus string, companyTy
   }
 }
 `
-
 }
 
 var apiURL = "https://api.companieshouse.gov.uk"
@@ -42,7 +43,7 @@ var apiURL = "https://api.companieshouse.gov.uk"
 func TestUnitCheckCompanyInsolvencyValid(t *testing.T) {
 
 	Convey("CheckCompanyInsolvencyValidFromCompanyProfileAPI", t, func() {
-
+		var companyProfile *companieshouseapi.CompanyProfile
 		httpmock.Activate()
 		defer httpmock.DeactivateAndReset()
 
@@ -51,10 +52,11 @@ func TestUnitCheckCompanyInsolvencyValid(t *testing.T) {
 			httpmock.RegisterResponder(http.MethodGet, apiURL+"/company/01234567", httpmock.NewStringResponder(http.StatusNotFound, "Message: Company not found"))
 
 			request := incomingInsolvencyRequest("01234567", "companyName", constants.CVL.String())
-			err, statusCode := CheckCompanyInsolvencyValid(request, &http.Request{})
+			err, statusCode, companyProfile := CheckCompanyExists(request, &http.Request{})
 			So(err, ShouldNotBeNil)
 			So(statusCode, ShouldEqual, http.StatusNotFound)
 			So(err.Error(), ShouldEqual, `company not found`)
+			So(companyProfile, ShouldBeNil)
 		})
 
 		Convey("Error contacting the company profile api", func() {
@@ -62,99 +64,47 @@ func TestUnitCheckCompanyInsolvencyValid(t *testing.T) {
 			httpmock.RegisterResponder(http.MethodGet, apiURL+"/company/01234567", httpmock.NewStringResponder(http.StatusTeapot, ""))
 
 			request := incomingInsolvencyRequest("01234567", "companyName", constants.CVL.String())
-			err, statusCode := CheckCompanyInsolvencyValid(request, &http.Request{})
+			err, statusCode, companyProfile := CheckCompanyExists(request, &http.Request{})
 			So(err, ShouldNotBeNil)
 			So(statusCode, ShouldEqual, http.StatusTeapot)
 			So(err.Error(), ShouldEqual, `error communicating with the company profile api`)
-		})
-
-		Convey("Provided company name does not match company profile api", func() {
-			defer httpmock.Reset()
-			httpmock.RegisterResponder(http.MethodGet, apiURL+"/company/01234567", httpmock.NewStringResponder(http.StatusOK,
-				companyProfileResponse("england-wales", "active", "private-shares-exemption-30")))
-
-			request := incomingInsolvencyRequest("01234567", "wrongName", constants.CVL.String())
-			err, statusCode := CheckCompanyInsolvencyValid(request, &http.Request{})
-			So(err, ShouldNotBeNil)
-			So(statusCode, ShouldEqual, http.StatusBadRequest)
-			So(err.Error(), ShouldEqual, `company names do not match - provided: [wrongName], expected: [COMPANYNAME]`)
-		})
-
-		Convey("Provided company name matches company profile api ignoring case sensitivity", func() {
-			defer httpmock.Reset()
-			httpmock.RegisterResponder(http.MethodGet, apiURL+"/company/01234567", httpmock.NewStringResponder(http.StatusOK,
-				companyProfileResponse("england-wales", "active", "private-shares-exemption-30")))
-
-			request := incomingInsolvencyRequest("01234567", "CompanyName", constants.CVL.String())
-			err, statusCode := CheckCompanyInsolvencyValid(request, &http.Request{})
-			So(err, ShouldBeNil)
-			So(statusCode, ShouldEqual, http.StatusOK)
+			So(companyProfile, ShouldBeNil)
 		})
 
 		Convey("Jurisdiction of company is not allowed to create insolvency case", func() {
-			defer httpmock.Reset()
-			httpmock.RegisterResponder(http.MethodGet, apiURL+"/company/01234567", httpmock.NewStringResponder(http.StatusOK,
-				companyProfileResponse("scotland", "active", "private-shares-exemption-30")))
+
+			var companyProfile *companieshouseapi.CompanyProfile
+			json.Unmarshal([]byte(companyProfileResponse("scotland", "active", "private-shares-exemption-30")), &companyProfile)
 
 			request := incomingInsolvencyRequest("01234567", "companyName", constants.CVL.String())
-			err, statusCode := CheckCompanyInsolvencyValid(request, &http.Request{})
+			err := CheckCompanyDetailsAreValid(companyProfile, request)
 			So(err, ShouldNotBeNil)
-			So(statusCode, ShouldEqual, http.StatusBadRequest)
 			So(err.Error(), ShouldEqual, `jurisdiction [scotland] not permitted`)
 		})
 
 		Convey("Company status is not allowed to create insolvency case", func() {
-			defer httpmock.Reset()
-			httpmock.RegisterResponder(http.MethodGet, apiURL+"/company/01234567", httpmock.NewStringResponder(http.StatusOK,
-				companyProfileResponse("england-wales", "dissolved", "private-shares-exemption-30")))
-
+			json.Unmarshal([]byte(companyProfileResponse("england-wales", "dissolved", "private-shares-exemption-30")), &companyProfile)
 			request := incomingInsolvencyRequest("01234567", "companyName", constants.CVL.String())
-			err, statusCode := CheckCompanyInsolvencyValid(request, &http.Request{})
+			// err, statusCode := CheckCompanyInsolvencyValid(request, &http.Request{})
+			err := CheckCompanyDetailsAreValid(companyProfile, request)
 			So(err, ShouldNotBeNil)
-			So(statusCode, ShouldEqual, http.StatusBadRequest)
+			// So(statusCode, ShouldEqual, http.StatusBadRequest)
 			So(err.Error(), ShouldEqual, `company status [dissolved] not permitted`)
 		})
 
 		Convey("Company type is not allowed to create insolvency case", func() {
-			defer httpmock.Reset()
-			httpmock.RegisterResponder(http.MethodGet, apiURL+"/company/01234567", httpmock.NewStringResponder(http.StatusOK,
-				companyProfileResponse("england-wales", "active", "converted-or-closed")))
-
+			json.Unmarshal([]byte(companyProfileResponse("england-wales", "active", "converted-or-closed")), &companyProfile)
 			request := incomingInsolvencyRequest("01234567", "companyName", constants.CVL.String())
-			err, statusCode := CheckCompanyInsolvencyValid(request, &http.Request{})
+			err := CheckCompanyDetailsAreValid(companyProfile, request)
 			So(err, ShouldNotBeNil)
-			So(statusCode, ShouldEqual, http.StatusBadRequest)
 			So(err.Error(), ShouldEqual, `company type [converted-or-closed] not permitted`)
 		})
 
 		Convey("Company is allowed to start insolvency case", func() {
-
-			alphakeyResponse := `{
-					"sameAsAlphaKey": "COMPANYNAME",
-					"orderedAlphaKey": "COMPANYNAME",
-					"upperCaseName": "COMPANYNAME"
-				}`
-
-			defer httpmock.Reset()
-			httpmock.RegisterResponder(http.MethodGet, apiURL+"/company/01234567", httpmock.NewStringResponder(http.StatusOK,
-				companyProfileResponse("england-wales", "active", "private-shares-exemption-30")))
-
-			httpmock.RegisterResponder(
-				http.MethodGet,
-				"http://localhost:4001/alphakey?name=companyName",
-				httpmock.NewStringResponder(http.StatusOK, alphakeyResponse),
-				)
-
-			httpmock.RegisterResponder(
-				http.MethodGet,
-				"http://localhost:4001/alphakey?name=COMPANYNAME",
-				httpmock.NewStringResponder(http.StatusOK, alphakeyResponse),
-			)
-
+			json.Unmarshal([]byte(companyProfileResponse("england-wales", "active", "private-shares-exemption-30")), &companyProfile)
 			request := incomingInsolvencyRequest("01234567", "companyName", constants.CVL.String())
-			err, statusCode := CheckCompanyInsolvencyValid(request, &http.Request{})
+			err := CheckCompanyDetailsAreValid(companyProfile, request)
 			So(err, ShouldBeNil)
-			So(statusCode, ShouldEqual, http.StatusOK)
 		})
 	})
 }


### PR DESCRIPTION
company name in title case were rejected by the api. added check to compare name against company profile api using the alpha key service - sameAsAlphaKey.
amended code to validate all other company details only if the company existed in company profile with a name and number match.