### PR TITLE
reverted to blocking LRESEX routes until CHIPS ready for LRESEX release

### DIFF
--- a/handlers/register.go
+++ b/handlers/register.go
@@ -45,15 +45,6 @@ func Register(mainRouter *mux.Router, svc dao.Service) {
 	publicAppRouter.Handle("/{transaction_id}/insolvency/practitioners/{practitioner_id}/appointment", HandleGetPractitionerAppointment(svc)).Methods(http.MethodGet).Name("getPractitionerAppointment")
 	publicAppRouter.Handle("/{transaction_id}/insolvency/practitioners/{practitioner_id}/appointment", HandleDeletePractitionerAppointment(svc)).Methods(http.MethodDelete).Name("deletePractitionerAppointment")
 
-	publicAppRouter.Handle("/{transaction_id}/insolvency/attachments", HandleSubmitAttachment(svc)).Methods(http.MethodPost).Name("submitAttachment")
-	publicAppRouter.Handle("/{transaction_id}/insolvency/attachments/{attachment_id}", HandleGetAttachmentDetails(svc)).Methods(http.MethodGet).Name("getAttachmentDetails")
-	publicAppRouter.Handle("/{transaction_id}/insolvency/attachments/{attachment_id}/download", HandleDownloadAttachment(svc)).Methods(http.MethodGet).Name("downloadAttachment")
-	publicAppRouter.Handle("/{transaction_id}/insolvency/attachments/{attachment_id}", HandleDeleteAttachment(svc)).Methods(http.MethodDelete).Name("deleteAttachment")
-
-	publicAppRouter.Handle("/{transaction_id}/insolvency/resolution", HandleCreateResolution(svc)).Methods(http.MethodPost).Name("createResolution")
-	publicAppRouter.Handle("/{transaction_id}/insolvency/resolution", HandleGetResolution(svc)).Methods(http.MethodGet).Name("getResolution")
-	publicAppRouter.Handle("/{transaction_id}/insolvency/resolution", HandleDeleteResolution(svc)).Methods(http.MethodDelete).Name("deleteResolution")
-
 	// Get environment config - only required whilst feature flag in use to disable
 	// non 600 form handling routes unless set to true
 	cfg, err := config.Get()
@@ -62,11 +53,19 @@ func Register(mainRouter *mux.Router, svc dao.Service) {
 	if err != nil {
 		log.Info("Failed to get config for EnableNon600RouteHandlers")
 	} else if cfg.EnableNon600RouteHandlers {
+		publicAppRouter.Handle("/{transaction_id}/insolvency/attachments", HandleSubmitAttachment(svc)).Methods(http.MethodPost).Name("submitAttachment")
+		publicAppRouter.Handle("/{transaction_id}/insolvency/attachments/{attachment_id}", HandleGetAttachmentDetails(svc)).Methods(http.MethodGet).Name("getAttachmentDetails")
+		publicAppRouter.Handle("/{transaction_id}/insolvency/attachments/{attachment_id}/download", HandleDownloadAttachment(svc)).Methods(http.MethodGet).Name("downloadAttachment")
+		publicAppRouter.Handle("/{transaction_id}/insolvency/attachments/{attachment_id}", HandleDeleteAttachment(svc)).Methods(http.MethodDelete).Name("deleteAttachment")
+
+		publicAppRouter.Handle("/{transaction_id}/insolvency/resolution", HandleCreateResolution(svc)).Methods(http.MethodPost).Name("createResolution")
+		publicAppRouter.Handle("/{transaction_id}/insolvency/resolution", HandleGetResolution(svc)).Methods(http.MethodGet).Name("getResolution")
+		publicAppRouter.Handle("/{transaction_id}/insolvency/resolution", HandleDeleteResolution(svc)).Methods(http.MethodDelete).Name("deleteResolution")
 		publicAppRouter.Handle("/{transaction_id}/insolvency/statement-of-affairs", HandleCreateStatementOfAffairs(svc)).Methods(http.MethodPost).Name("createStatementOfAffairs")
 		publicAppRouter.Handle("/{transaction_id}/insolvency/statement-of-affairs", HandleGetStatementOfAffairs(svc)).Methods(http.MethodGet).Name("getStatementOfAffairs")
 		publicAppRouter.Handle("/{transaction_id}/insolvency/statement-of-affairs", HandleDeleteStatementOfAffairs(svc)).Methods(http.MethodDelete).Name("deleteStatementOfAffairs")
 	} else {
-		log.Info("LIQ02 endpoints blocked")
+		log.Info("LRESEX and LIQ02 endpoints blocked")
 	}
 
 	// Create a private router that requires all users to be authenticated when making requests

--- a/handlers/register_test.go
+++ b/handlers/register_test.go
@@ -39,14 +39,14 @@ func TestUnitRegisterRoutes(t *testing.T) {
 		So(router.GetRoute("getPractitionerAppointment"), ShouldNotBeNil)
 		So(router.GetRoute("deletePractitionerAppointment"), ShouldNotBeNil)
 
-		So(router.GetRoute("submitAttachment"), ShouldNotBeNil)
-		So(router.GetRoute("getAttachmentDetails"), ShouldNotBeNil)
-		So(router.GetRoute("downloadAttachment"), ShouldNotBeNil)
-		So(router.GetRoute("deleteAttachment"), ShouldNotBeNil)
+		So(router.GetRoute("submitAttachment"), ShouldBeNil)
+		So(router.GetRoute("getAttachmentDetails"), ShouldBeNil)
+		So(router.GetRoute("downloadAttachment"), ShouldBeNil)
+		So(router.GetRoute("deleteAttachment"), ShouldBeNil)
 
-		So(router.GetRoute("createResolution"), ShouldNotBeNil)
-		So(router.GetRoute("getResolution"), ShouldNotBeNil)
-		So(router.GetRoute("deleteResolution"), ShouldNotBeNil)
+		So(router.GetRoute("createResolution"), ShouldBeNil)
+		So(router.GetRoute("getResolution"), ShouldBeNil)
+		So(router.GetRoute("deleteResolution"), ShouldBeNil)
 
 		So(router.GetRoute("createStatementOfAffairs"), ShouldBeNil)
 		So(router.GetRoute("getStatementOfAffairs"), ShouldBeNil)


### PR DESCRIPTION
Reverted exposing LRESEX endpoints.
Changes relating to 600 need to go live and LRESEX is not ready for live yet.

test environments if required to test LRESEX endpoints will need ENABLE_NON600_ROUTE_HANDLERS=true