### PR TITLE
Return HTTP 400 Bad Request for bad request body [IEP-664]

### DIFF
--- a/handlers/attachment_resource_test.go
+++ b/handlers/attachment_resource_test.go
@@ -120,20 +120,19 @@ func TestUnitHandleSubmitAttachment(t *testing.T) {
 		So(res.Body.String(), ShouldContainSubstring, "already closed and cannot be updated")
 	})
 
-	Convey("Failed to read request body", t, func() {
-		mockService, mockHelperService, rec := mock_dao.CreateTestObjects(t)
+	Convey("Failed to read form from request body", t, func() {
+		mockService, _, rec := mock_dao.CreateTestObjects(t)
 		httpmock.Activate()
 
 		// Expect the transaction api to be called and return an open transaction
 		httpmock.RegisterResponder(http.MethodGet, "https://api.companieshouse.gov.uk/transactions/12345678", httpmock.NewStringResponder(http.StatusOK, transactionProfileResponse))
 
 		body := []byte(`{"company_name":error`)
-		mockHelperService.EXPECT().HandleTransactionIdExistsValidation(gomock.Any(), gomock.Any(), transactionID).Return(true, transactionID).AnyTimes()
-		mockHelperService.EXPECT().HandleTransactionNotClosedValidation(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 
-		res := serveHandleSubmitAttachment(body, mockService, true, mockHelperService, rec)
+		res := serveHandleSubmitAttachment(body, mockService, true, helperService, rec)
 
 		So(res.Code, ShouldEqual, http.StatusBadRequest)
+		So(res.Body.String(), ShouldContainSubstring, "error reading form from request")
 	})
 
 	Convey("Validation failed - invalid attachment type", t, func() {

--- a/handlers/insolvency_resource_test.go
+++ b/handlers/insolvency_resource_test.go
@@ -109,7 +109,7 @@ func TestUnitHandleCreateInsolvencyResource(t *testing.T) {
 
 		res := serveHandleCreateInsolvencyResource(body, mockService, true, helperService, rec)
 
-		So(res.Code, ShouldEqual, http.StatusInternalServerError)
+		So(res.Code, ShouldEqual, http.StatusBadRequest)
 		So(res.Body.String(), ShouldContainSubstring, "failed to read request body for transaction")
 	})
 

--- a/handlers/practitioner_resource_test.go
+++ b/handlers/practitioner_resource_test.go
@@ -96,7 +96,7 @@ func TestUnitHandleCreatePractitionersResource(t *testing.T) {
 
 		res := serveHandleCreatePractitionersResource(body, mockService, helperService, true, rec)
 
-		So(res.Code, ShouldEqual, http.StatusInternalServerError)
+		So(res.Code, ShouldEqual, http.StatusBadRequest)
 		So(res.Body.String(), ShouldContainSubstring, "failed to read request body for transaction")
 	})
 
@@ -952,7 +952,7 @@ func TestUnitHandleAppointPractitioner(t *testing.T) {
 
 		res := serveHandleAppointPractitioner(body, mockService, helperService, true, true, rec)
 
-		So(res.Code, ShouldEqual, http.StatusInternalServerError)
+		So(res.Code, ShouldEqual, http.StatusBadRequest)
 		So(res.Body.String(), ShouldContainSubstring, "failed to read request body for transaction")
 	})
 

--- a/handlers/progress_report_resource_test.go
+++ b/handlers/progress_report_resource_test.go
@@ -94,7 +94,7 @@ func TestUnitHandleCreateProgressReport(t *testing.T) {
 
 		res := serveHandleCreateProgressReport(body, mockService, helperService, true, rec)
 
-		So(res.Code, ShouldEqual, http.StatusInternalServerError)
+		So(res.Code, ShouldEqual, http.StatusBadRequest)
 		So(res.Body.String(), ShouldContainSubstring, fmt.Sprintf("failed to read request body for transaction %s", transactionID))
 	})
 

--- a/handlers/resolution_resource_test.go
+++ b/handlers/resolution_resource_test.go
@@ -93,7 +93,7 @@ func TestUnitHandleCreateResolution(t *testing.T) {
 
 		res := serveHandleCreateResolution(body, mockService, helperService, true, rec)
 
-		So(res.Code, ShouldEqual, http.StatusInternalServerError)
+		So(res.Code, ShouldEqual, http.StatusBadRequest)
 		So(res.Body.String(), ShouldContainSubstring, fmt.Sprintf("failed to read request body for transaction %s", transactionID))
 	})
 

--- a/handlers/soa_resource_test.go
+++ b/handlers/soa_resource_test.go
@@ -93,7 +93,7 @@ func TestUnitHandleCreateStatementOfAffairs(t *testing.T) {
 
 		res := serveHandleCreateStatementOfAffairs(body, mockService, helperService, true, rec)
 
-		So(res.Code, ShouldEqual, http.StatusInternalServerError)
+		So(res.Code, ShouldEqual, http.StatusBadRequest)
 		So(res.Body.String(), ShouldContainSubstring, fmt.Sprintf("failed to read request body for transaction %s", transactionID))
 	})
 

--- a/utils/common_validation.go
+++ b/utils/common_validation.go
@@ -2,9 +2,10 @@ package utils
 
 import (
 	"fmt"
+	"net/http"
+
 	"github.com/companieshouse/chs.go/log"
 	"github.com/companieshouse/insolvency-api/models"
-	"net/http"
 )
 
 // HelperService interface declares
@@ -58,7 +59,7 @@ func (*helperService) HandleBodyDecodedValidation(w http.ResponseWriter, req *ht
 	if err != nil {
 		log.ErrorR(req, fmt.Errorf("invalid request"))
 		m := models.NewMessageResponse(fmt.Sprintf("failed to read request body for transaction %s", transactionID))
-		WriteJSONWithStatus(w, req, m, http.StatusInternalServerError)
+		WriteJSONWithStatus(w, req, m, http.StatusBadRequest)
 		return false
 	}
 	return true


### PR DESCRIPTION
Amended helper method HandleBodyDecodedValidation to return http.StatusBadRequest on error & updated relevant unit test checks to match.

One unit test check which shared the same name (in attachment_resource_test) was actually performing a slightly different check, so I have amended the name of the 'Convey' scope to reflect this (and as I was touching it I also updated the test to use the real helperService & added an error message check based on its current behaviour).