### PR TITLE
IEP-639 - Update response bodies for LIQ02

### DIFF
--- a/dao/mongo.go
+++ b/dao/mongo.go
@@ -600,6 +600,9 @@ func (m *MongoService) CreateStatementOfAffairsResource(dao *models.StatementOfA
 	statementDao := models.StatementOfAffairsResourceDao{
 		StatementDate: dao.StatementDate,
 		Attachments:   dao.Attachments,
+		Kind:          dao.Kind,
+		Etag:          dao.Etag,
+		Links:         dao.Links,
 	}
 
 	// Retrieve insolvency case from Mongo

--- a/handlers/soa_resource.go
+++ b/handlers/soa_resource.go
@@ -32,7 +32,7 @@ func HandleCreateStatementOfAffairs(svc dao.Service, helperService utils.HelperS
 			return
 		}
 
-		statementDao := transformers.StatementOfAffairsResourceRequestToDB(&request)
+		statementDao := transformers.StatementOfAffairsResourceRequestToDB(&request, transactionID, helperService)
 
 		// Validate all mandatory fields
 		errs := utils.Validate(request)
@@ -117,7 +117,7 @@ func HandleGetStatementOfAffairs(svc dao.Service) http.Handler {
 
 		log.InfoR(req, fmt.Sprintf("successfully retrieved statement of affairs resource with transaction ID: %s, from mongo", transactionID))
 
-		utils.WriteJSONWithStatus(w, req, statementOfAffairs, http.StatusOK)
+		utils.WriteJSONWithStatus(w, req, transformers.StatementOfAffairsDaoToResponse(&statementOfAffairs), http.StatusOK)
 	})
 }
 

--- a/handlers/soa_resource_test.go
+++ b/handlers/soa_resource_test.go
@@ -171,7 +171,7 @@ func TestUnitHandleCreateStatementOfAffairs(t *testing.T) {
 	})
 
 	Convey("Failed to validate statement of affairs", t, func() {
-		mockService, mockHelperService, rec := mock_dao.CreateTestObjects(t)
+		mockService, _, rec := mock_dao.CreateTestObjects(t)
 		httpmock.Activate()
 
 		httpmock.RegisterResponder(http.MethodGet, "https://api.companieshouse.gov.uk/company/1234", httpmock.NewStringResponder(http.StatusOK, companyProfileDateResponse("2000-06-26 00:00:00.000Z")))
@@ -182,20 +182,16 @@ func TestUnitHandleCreateStatementOfAffairs(t *testing.T) {
 		statement := generateStatement()
 
 		body, _ := json.Marshal(statement)
-		mockHelperService.EXPECT().HandleTransactionIdExistsValidation(gomock.Any(), gomock.Any(), transactionID).Return(true, transactionID).AnyTimes()
-		mockHelperService.EXPECT().HandleTransactionNotClosedValidation(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true).AnyTimes()
-		mockHelperService.EXPECT().HandleBodyDecodedValidation(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true).AnyTimes()
-		mockHelperService.EXPECT().HandleMandatoryFieldValidation(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 		mockService.EXPECT().GetInsolvencyResource(transactionID).Return(models.InsolvencyResourceDao{}, fmt.Errorf("error"))
 
-		res := serveHandleCreateStatementOfAffairs(body, mockService, mockHelperService, true, rec)
+		res := serveHandleCreateStatementOfAffairs(body, mockService, helperService, true, rec)
 
 		So(res.Code, ShouldEqual, http.StatusInternalServerError)
 		So(res.Body.String(), ShouldContainSubstring, "there was a problem handling your request for transaction ID")
 	})
 
 	Convey("Validation errors are present - date is in the past", t, func() {
-		mockService, mockHelperService, rec := mock_dao.CreateTestObjects(t)
+		mockService, _, rec := mock_dao.CreateTestObjects(t)
 		httpmock.Activate()
 
 		httpmock.RegisterResponder(http.MethodGet, "https://api.companieshouse.gov.uk/company/1234", httpmock.NewStringResponder(http.StatusOK, companyProfileDateResponse("2000-06-26 00:00:00.000Z")))
@@ -207,20 +203,16 @@ func TestUnitHandleCreateStatementOfAffairs(t *testing.T) {
 		statement.StatementDate = "1999-01-01"
 
 		body, _ := json.Marshal(statement)
-		mockHelperService.EXPECT().HandleTransactionIdExistsValidation(gomock.Any(), gomock.Any(), transactionID).Return(true, transactionID).AnyTimes()
-		mockHelperService.EXPECT().HandleTransactionNotClosedValidation(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true).AnyTimes()
-		mockHelperService.EXPECT().HandleBodyDecodedValidation(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true).AnyTimes()
-		mockHelperService.EXPECT().HandleMandatoryFieldValidation(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 		mockService.EXPECT().GetInsolvencyResource(transactionID).Return(generateInsolvencyResource(), nil)
 
-		res := serveHandleCreateStatementOfAffairs(body, mockService, mockHelperService, true, rec)
+		res := serveHandleCreateStatementOfAffairs(body, mockService, helperService, true, rec)
 
 		So(res.Code, ShouldEqual, http.StatusBadRequest)
 		So(res.Body.String(), ShouldContainSubstring, "statement_date [1999-01-01] should not be in the future or before the company was incorporated")
 	})
 
 	Convey("Validation errors are present - multiple attachments", t, func() {
-		mockService, mockHelperService, rec := mock_dao.CreateTestObjects(t)
+		mockService, _, rec := mock_dao.CreateTestObjects(t)
 		httpmock.Activate()
 
 		httpmock.RegisterResponder(http.MethodGet, "https://api.companieshouse.gov.uk/company/1234", httpmock.NewStringResponder(http.StatusOK, companyProfileDateResponse("2000-06-26 00:00:00.000Z")))
@@ -235,20 +227,16 @@ func TestUnitHandleCreateStatementOfAffairs(t *testing.T) {
 		}
 
 		body, _ := json.Marshal(statement)
-		mockHelperService.EXPECT().HandleTransactionIdExistsValidation(gomock.Any(), gomock.Any(), transactionID).Return(true, transactionID).AnyTimes()
-		mockHelperService.EXPECT().HandleTransactionNotClosedValidation(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true).AnyTimes()
-		mockHelperService.EXPECT().HandleBodyDecodedValidation(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true).AnyTimes()
-		mockHelperService.EXPECT().HandleMandatoryFieldValidation(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 		mockService.EXPECT().GetInsolvencyResource(transactionID).Return(generateInsolvencyResource(), nil)
 
-		res := serveHandleCreateStatementOfAffairs(body, mockService, mockHelperService, true, rec)
+		res := serveHandleCreateStatementOfAffairs(body, mockService, helperService, true, rec)
 
 		So(res.Code, ShouldEqual, http.StatusBadRequest)
 		So(res.Body.String(), ShouldContainSubstring, "please supply only one attachment")
 	})
 
 	Convey("Validation errors are present - no attachment is present", t, func() {
-		mockService, mockHelperService, rec := mock_dao.CreateTestObjects(t)
+		mockService, _, rec := mock_dao.CreateTestObjects(t)
 		httpmock.Activate()
 
 		httpmock.RegisterResponder(http.MethodGet, "https://api.companieshouse.gov.uk/company/1234", httpmock.NewStringResponder(http.StatusOK, companyProfileDateResponse("2000-06-26 00:00:00.000Z")))
@@ -260,20 +248,16 @@ func TestUnitHandleCreateStatementOfAffairs(t *testing.T) {
 		statement.Attachments = []string{}
 
 		body, _ := json.Marshal(statement)
-		mockHelperService.EXPECT().HandleTransactionIdExistsValidation(gomock.Any(), gomock.Any(), transactionID).Return(true, transactionID).AnyTimes()
-		mockHelperService.EXPECT().HandleTransactionNotClosedValidation(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true).AnyTimes()
-		mockHelperService.EXPECT().HandleBodyDecodedValidation(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true).AnyTimes()
-		mockHelperService.EXPECT().HandleMandatoryFieldValidation(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 		mockService.EXPECT().GetInsolvencyResource(transactionID).Return(generateInsolvencyResource(), nil)
 
-		res := serveHandleCreateStatementOfAffairs(body, mockService, mockHelperService, true, rec)
+		res := serveHandleCreateStatementOfAffairs(body, mockService, helperService, true, rec)
 
 		So(res.Code, ShouldEqual, http.StatusBadRequest)
 		So(res.Body.String(), ShouldContainSubstring, "please supply only one attachment")
 	})
 
 	Convey("Attachment is not of type statement-of-affairs-director or liquidator", t, func() {
-		mockService, mockHelperService, rec := mock_dao.CreateTestObjects(t)
+		mockService, _, rec := mock_dao.CreateTestObjects(t)
 		httpmock.Activate()
 
 		httpmock.RegisterResponder(http.MethodGet, "https://api.companieshouse.gov.uk/company/1234", httpmock.NewStringResponder(http.StatusOK, companyProfileDateResponse("2000-06-26 00:00:00.000Z")))
@@ -287,17 +271,11 @@ func TestUnitHandleCreateStatementOfAffairs(t *testing.T) {
 		attachment.Type = "not-soa"
 
 		body, _ := json.Marshal(statement)
-		mockHelperService.EXPECT().HandleTransactionIdExistsValidation(gomock.Any(), gomock.Any(), transactionID).Return(true, transactionID).AnyTimes()
-		mockHelperService.EXPECT().HandleTransactionNotClosedValidation(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true).AnyTimes()
-		mockHelperService.EXPECT().HandleBodyDecodedValidation(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true).AnyTimes()
-		mockHelperService.EXPECT().HandleMandatoryFieldValidation(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 		mockService.EXPECT().GetInsolvencyResource(transactionID).Return(generateInsolvencyResource(), nil)
-		mockHelperService.EXPECT().HandleAttachmentValidation(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true).AnyTimes()
-		mockHelperService.EXPECT().HandleAttachmentTypeValidation(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(http.StatusBadRequest).AnyTimes()
 		// Expect GetAttachmentFromInsolvencyResource to be called once and return attachment, nil
 		mockService.EXPECT().GetAttachmentFromInsolvencyResource(transactionID, statement.Attachments[0]).Return(attachment, nil)
 
-		res := serveHandleCreateStatementOfAffairs(body, mockService, mockHelperService, true, rec)
+		res := serveHandleCreateStatementOfAffairs(body, mockService, helperService, true, rec)
 
 		So(res.Code, ShouldEqual, http.StatusBadRequest)
 		So(res.Body.String(), ShouldContainSubstring, "attachment is not a statement-of-affairs-director or statement-of-affairs-liquidator")
@@ -358,7 +336,7 @@ func TestUnitHandleCreateStatementOfAffairs(t *testing.T) {
 	})
 
 	Convey("Successfully add insolvency resource to mongo", t, func() {
-		mockService, mockHelperService, rec := mock_dao.CreateTestObjects(t)
+		mockService, _, rec := mock_dao.CreateTestObjects(t)
 		httpmock.Activate()
 
 		httpmock.RegisterResponder(http.MethodGet, "https://api.companieshouse.gov.uk/company/1234", httpmock.NewStringResponder(http.StatusOK, companyProfileDateResponse("2000-06-26 00:00:00.000Z")))
@@ -376,21 +354,20 @@ func TestUnitHandleCreateStatementOfAffairs(t *testing.T) {
 			Links:  models.AttachmentResourceLinksDao{},
 		}
 
-		mockHelperService.EXPECT().HandleTransactionIdExistsValidation(gomock.Any(), gomock.Any(), transactionID).Return(true, transactionID).AnyTimes()
-		mockHelperService.EXPECT().HandleTransactionNotClosedValidation(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true).AnyTimes()
-		mockHelperService.EXPECT().HandleBodyDecodedValidation(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true).AnyTimes()
-		mockHelperService.EXPECT().HandleMandatoryFieldValidation(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 		mockService.EXPECT().GetInsolvencyResource(transactionID).Return(generateInsolvencyResource(), nil)
 		// Expect GetAttachmentFromInsolvencyResource to be called once and return attachment, nil
 		mockService.EXPECT().GetAttachmentFromInsolvencyResource(transactionID, statement.Attachments[0]).Return(attachment, nil)
-		mockHelperService.EXPECT().HandleAttachmentValidation(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 		// Expect CreateStatementOfAffairsResource to be called once and return an error
 		mockService.EXPECT().CreateStatementOfAffairsResource(gomock.Any(), transactionID).Return(http.StatusCreated, nil).Times(1)
-		mockHelperService.EXPECT().HandleCreateResourceValidation(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 
-		res := serveHandleCreateStatementOfAffairs(body, mockService, mockHelperService, true, rec)
+		res := serveHandleCreateStatementOfAffairs(body, mockService, helperService, true, rec)
 
 		So(res.Code, ShouldEqual, http.StatusOK)
+		So(res.Body.String(), ShouldContainSubstring, "etag")
+		So(res.Body.String(), ShouldContainSubstring, "kind")
+		So(res.Body.String(), ShouldContainSubstring, "links")
+		So(res.Body.String(), ShouldContainSubstring, "statement_date")
+		So(res.Body.String(), ShouldContainSubstring, "attachments")
 	})
 }
 
@@ -461,17 +438,28 @@ func TestUnitHandleGetStatementOfAffairs(t *testing.T) {
 		mockService := mock_dao.NewMockService(mockCtrl)
 
 		statementOfAffairs := models.StatementOfAffairsResourceDao{
+			Etag:          "6f143c1f8109d834263eb764c5f020a0ae3ff78ee1789477179cb80f",
+			Kind:          "insolvency-resource#statement-of-affairs",
 			StatementDate: "2021-06-06",
 			Attachments: []string{
 				"1223-3445-5667",
 			},
+			Links: models.StatementOfAffairsResourceLinksDao{
+				Self: "/transactions/12345678/insolvency/statement-of-affairs",
+			},
 		}
+
 		// Expect GetStatementOfAffairsResource to be called once and return statement of affairs
 		mockService.EXPECT().GetStatementOfAffairsResource(transactionID).Return(statementOfAffairs, nil)
 
 		res := serveHandleGetStatementOfAffairs(mockService, true)
 
 		So(res.Code, ShouldEqual, http.StatusOK)
+		So(res.Body.String(), ShouldContainSubstring, "etag")
+		So(res.Body.String(), ShouldContainSubstring, "kind")
+		So(res.Body.String(), ShouldContainSubstring, "links")
+		So(res.Body.String(), ShouldContainSubstring, "statement_date")
+		So(res.Body.String(), ShouldContainSubstring, "attachments")
 	})
 }
 

--- a/models/data_entities.go
+++ b/models/data_entities.go
@@ -104,8 +104,16 @@ type ResolutionResourceLinksDao struct {
 
 // StatementOfAffairsResourceDao contains the data for the statement of affairs DB resource
 type StatementOfAffairsResourceDao struct {
-	StatementDate string   `bson:"statement_date"`
-	Attachments   []string `bson:"attachments"`
+	Etag          string                             `bson:"etag"`
+	Kind          string                             `bson:"kind"`
+	StatementDate string                             `bson:"statement_date"`
+	Attachments   []string                           `bson:"attachments"`
+	Links         StatementOfAffairsResourceLinksDao `bson:"links"`
+}
+
+// StatementOfAffairsResourceLinksDao contains the Links data for a statement of affairs
+type StatementOfAffairsResourceLinksDao struct {
+	Self string `bson:"self,omitempty"`
 }
 
 type ProgressReportResourceDao struct {

--- a/models/response_entities.go
+++ b/models/response_entities.go
@@ -99,7 +99,16 @@ type ResolutionResourceLinks struct {
 // StatementOfAffairsResource contains the details of the statement of affairs resource
 
 type StatementOfAffairsResource struct {
-	StatementDate string `json:"statement_date"`
+	StatementDate string                          `json:"statement_date"`
+	Attachments   []string                        `json:"attachments"`
+	Etag          string                          `json:"etag"`
+	Kind          string                          `json:"kind"`
+	Links         StatementOfAffairsResourceLinks `json:"links"`
+}
+
+// StatementOfAffairsResourceLinks contains the links details for a statement of affairs
+type StatementOfAffairsResourceLinks struct {
+	Self string `json:"self"`
 }
 
 type ProgressReportResource struct {

--- a/service/progress_report_service.go
+++ b/service/progress_report_service.go
@@ -15,6 +15,12 @@ import (
 func ValidateProgressReportDetails(svc dao.Service, progressReportStatementDao *models.ProgressReportResourceDao, transactionID string, req *http.Request) (string, error) {
 	var errs []string
 
+	if progressReportStatementDao == nil {
+		err := fmt.Errorf("nil DAO passed to service for validation")
+		log.ErrorR(req, err)
+		return "", err
+	}
+
 	// Check that the attachment has been submitted correctly
 	if len(progressReportStatementDao.Attachments) == 0 || len(progressReportStatementDao.Attachments) > 1 {
 		errs = append(errs, "please supply only one attachment")

--- a/service/progress_report_service_test.go
+++ b/service/progress_report_service_test.go
@@ -2,10 +2,11 @@ package service
 
 import (
 	"fmt"
-	"github.com/companieshouse/insolvency-api/mocks"
 	"net/http"
 	"testing"
 	"time"
+
+	"github.com/companieshouse/insolvency-api/mocks"
 
 	"github.com/companieshouse/insolvency-api/models"
 	"github.com/jarcoal/httpmock"
@@ -197,6 +198,18 @@ func TestValidProgressReport(t *testing.T) {
 		So(validationErr, ShouldBeEmpty)
 		So(err, ShouldBeNil)
 	})
+
+	Convey("nil dao", t, func() {
+		mockService, _, _ := mocks.CreateTestObjects(t)
+		httpmock.Activate()
+
+		httpmock.RegisterResponder(http.MethodGet, apiURL+"/company/1234", httpmock.NewStringResponder(http.StatusOK, companyProfileDateResponse("2000-06-26 00:00:00.000Z")))
+
+		validationErr, err := ValidateProgressReportDetails(mockService, nil, transactionID, req)
+		So(validationErr, ShouldBeEmpty)
+		So(err.Error(), ShouldContainSubstring, "nil DAO passed to service for validation")
+	})
+
 }
 
 func generateProgressReport() models.ProgressReportResourceDao {

--- a/service/soa_service.go
+++ b/service/soa_service.go
@@ -15,6 +15,12 @@ import (
 func ValidateStatementDetails(svc dao.Service, statementDao *models.StatementOfAffairsResourceDao, transactionID string, req *http.Request) (string, error) {
 	var errs []string
 
+	if statementDao == nil {
+		err := fmt.Errorf("nil DAO passed to service for validation")
+		log.ErrorR(req, err)
+		return "", err
+	}
+
 	// Check that the attachment has been submitted correctly
 	if len(statementDao.Attachments) == 0 || len(statementDao.Attachments) > 1 {
 		errs = append(errs, "please supply only one attachment")

--- a/service/soa_service_test.go
+++ b/service/soa_service_test.go
@@ -186,6 +186,21 @@ func TestUnitIsValidStatementDate(t *testing.T) {
 		So(err, ShouldBeNil)
 	})
 
+	Convey("nil dao", t, func() {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		defer httpmock.Reset()
+		httpmock.RegisterResponder(http.MethodGet, apiURL+"/company/1234", httpmock.NewStringResponder(http.StatusOK, companyProfileDateResponse("2000-06-26 00:00:00.000Z")))
+
+		mockService := mocks.NewMockService(mockCtrl)
+
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		validationErr, err := ValidateStatementDetails(mockService, nil, transactionID, req)
+		So(validationErr, ShouldBeEmpty)
+		So(err.Error(), ShouldContainSubstring, "nil DAO passed to service for validation")
+	})
+
 }
 
 func generateStatement() models.StatementOfAffairsResourceDao {

--- a/transformers/soa_resource.go
+++ b/transformers/soa_resource.go
@@ -1,14 +1,34 @@
 package transformers
 
 import (
+	"fmt"
+
+	"github.com/companieshouse/chs.go/log"
+	"github.com/companieshouse/insolvency-api/constants"
 	"github.com/companieshouse/insolvency-api/models"
+	"github.com/companieshouse/insolvency-api/utils"
 )
 
 // StatementOfAffairsResourceRequestToDB transforms a statement of affairs request to a dao model
-func StatementOfAffairsResourceRequestToDB(req *models.StatementOfAffairs) *models.StatementOfAffairsResourceDao {
+func StatementOfAffairsResourceRequestToDB(req *models.StatementOfAffairs, transactionID string, helperService utils.HelperService) *models.StatementOfAffairsResourceDao {
+
+	etag, err := helperService.GenerateEtag()
+
+	if err != nil {
+		log.Error(fmt.Errorf("error generating etag: [%s] and etag is empty", err))
+		return nil
+	}
+
+	selfLink := fmt.Sprintf(constants.TransactionsPath + transactionID + "/insolvency/statement-of-affairs")
+
 	dao := &models.StatementOfAffairsResourceDao{
+		Etag:          etag,
+		Kind:          "insolvency-resource#statement-of-affairs",
 		StatementDate: req.StatementDate,
 		Attachments:   req.Attachments,
+		Links: models.StatementOfAffairsResourceLinksDao{
+			Self: selfLink,
+		},
 	}
 
 	return dao
@@ -18,5 +38,9 @@ func StatementOfAffairsResourceRequestToDB(req *models.StatementOfAffairs) *mode
 func StatementOfAffairsDaoToResponse(statement *models.StatementOfAffairsResourceDao) *models.StatementOfAffairsResource {
 	return &models.StatementOfAffairsResource{
 		StatementDate: statement.StatementDate,
+		Attachments:   statement.Attachments,
+		Etag:          statement.Etag,
+		Kind:          statement.Kind,
+		Links:         models.StatementOfAffairsResourceLinks(statement.Links),
 	}
 }

--- a/transformers/soa_resource_test.go
+++ b/transformers/soa_resource_test.go
@@ -1,40 +1,98 @@
 package transformers
 
 import (
+	"fmt"
 	"testing"
 
+	mock_dao "github.com/companieshouse/insolvency-api/mocks"
 	"github.com/companieshouse/insolvency-api/models"
+	"github.com/companieshouse/insolvency-api/utils"
+	"github.com/golang/mock/gomock"
 
 	. "github.com/smartystreets/goconvey/convey"
 )
 
 func TestUnitStatementOfAffairsResourceRequestToDB(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
 	Convey("field mappings are correct", t, func() {
-		dao := &models.StatementOfAffairs{
+		req := &models.StatementOfAffairs{
 			StatementDate: "2021-06-06",
 			Attachments: []string{
 				"1234567890",
 			},
 		}
 
-		response := StatementOfAffairsResourceRequestToDB(dao)
+		dao := StatementOfAffairsResourceRequestToDB(req, "transactionID", utils.NewHelperService())
 
-		So(response.StatementDate, ShouldEqual, dao.StatementDate)
-		So(response.Attachments, ShouldResemble, dao.Attachments)
+		So(dao.StatementDate, ShouldEqual, req.StatementDate)
+		So(dao.Attachments, ShouldResemble, req.Attachments)
+		So(dao.Etag, ShouldNotBeNil)
+		So(dao.Kind, ShouldEqual, "insolvency-resource#statement-of-affairs")
+		So(dao.Links.Self, ShouldNotBeNil)
+	})
+
+	Convey("Etag failed to generate", t, func() {
+
+		mockHelperService := mock_dao.NewHelperMockHelperService(mockCtrl)
+
+		req := &models.StatementOfAffairs{
+			StatementDate: "2021-06-06",
+			Attachments: []string{
+				"1234567890",
+			},
+		}
+
+		mockHelperService.EXPECT().GenerateEtag().Return("", fmt.Errorf("err"))
+
+		dao := StatementOfAffairsResourceRequestToDB(req, "transactionID", mockHelperService)
+
+		So(dao, ShouldBeNil)
+
+	})
+
+	Convey("Etag generated not validated", t, func() {
+
+		mockHelperService := mock_dao.NewHelperMockHelperService(mockCtrl)
+
+		req := &models.StatementOfAffairs{
+			StatementDate: "2021-06-06",
+			Attachments: []string{
+				"1234567890",
+			},
+		}
+
+		mockHelperService.EXPECT().GenerateEtag().Return("", fmt.Errorf("err"))
+		mockHelperService.EXPECT().HandleEtagGenerationValidation(gomock.Any()).Return(false).AnyTimes()
+
+		dao := StatementOfAffairsResourceRequestToDB(req, "transactionID", mockHelperService)
+
+		So(dao, ShouldBeNil)
+
 	})
 }
 
 func TestUnitStatementOfAffairsDaoToResponse(t *testing.T) {
 	Convey("field mappings are correct", t, func() {
 		dao := &models.StatementOfAffairsResourceDao{
+			Etag:          "6f143c1f8109d834263eb764c5f020a0ae3ff78ee1789477179cb80f",
+			Kind:          "insolvency-resource#statement-of-affairs",
 			StatementDate: "2021-06-06",
 			Attachments: []string{
 				"1234567890",
+			},
+			Links: models.StatementOfAffairsResourceLinksDao{
+				Self: "/transactions/12345678/insolvency/statement-of-affairs",
 			},
 		}
 
 		response := StatementOfAffairsDaoToResponse(dao)
 
 		So(response.StatementDate, ShouldEqual, dao.StatementDate)
+		So(response.Attachments, ShouldResemble, dao.Attachments)
+		So(response.Etag, ShouldEqual, dao.Etag)
+		So(response.Kind, ShouldEqual, dao.Kind)
+		So(response.Links.Self, ShouldEqual, dao.Links.Self)
 	})
 }


### PR DESCRIPTION
Added missing fields to data structures & included them in response bodies (similar to previous work for LRESEX equivalent). 
Added call to transformer to ensure that GET response field names are formatted correctly.
Switched some unit tests to use the real helperService as part of this work due to etag generation being handled there.
Added check for nil DAO to service-level validation (in progress service too) due to etag generation failure returning nil DAO.