### PR TITLE
IEP-704 - Remove duplicate HTTP error messages

### DIFF
--- a/handlers/progress_report_resource.go
+++ b/handlers/progress_report_resource.go
@@ -67,8 +67,7 @@ func HandleCreateProgressReport(svc dao.Service, helperService utils.HelperServi
 			err := fmt.Errorf("attachment id [%s] is an invalid type for this request: %v", progressReportDao.Attachments[0], attachment.Type)
 			responseMessage := "attachment is not a progress-report"
 
-			httpStatusCode := helperService.HandleAttachmentTypeValidation(w, req, responseMessage, err)
-			http.Error(w, responseMessage, httpStatusCode)
+			helperService.HandleAttachmentTypeValidation(w, req, responseMessage, err)
 			return
 		}
 

--- a/handlers/resolution_resource.go
+++ b/handlers/resolution_resource.go
@@ -76,8 +76,7 @@ func HandleCreateResolution(svc dao.Service, helperService utils.HelperService) 
 			err := fmt.Errorf("attachment id [%s] is an invalid type for this request: %v", resolutionDao.Attachments[0], attachment.Type)
 			responseMessage := "attachment is not a resolution"
 
-			httpStatusCode := helperService.HandleAttachmentTypeValidation(w, req, responseMessage, err)
-			http.Error(w, responseMessage, httpStatusCode)
+			helperService.HandleAttachmentTypeValidation(w, req, responseMessage, err)
 			return
 		}
 

--- a/handlers/soa_resource.go
+++ b/handlers/soa_resource.go
@@ -68,8 +68,7 @@ func HandleCreateStatementOfAffairs(svc dao.Service, helperService utils.HelperS
 			err := fmt.Errorf("attachment id [%s] is an invalid type for this request: %v", statementDao.Attachments[0], attachment.Type)
 			responseMessage := "attachment is not a statement-of-affairs-director or statement-of-affairs-liquidator"
 
-			httpStatusCode := helperService.HandleAttachmentTypeValidation(w, req, responseMessage, err)
-			http.Error(w, responseMessage, httpStatusCode)
+			helperService.HandleAttachmentTypeValidation(w, req, responseMessage, err)
 			return
 		}
 


### PR DESCRIPTION
Removed duplicate HTTP error messages and updated related unit tests to use real helperService so that actual responses can be checked.