### PR TITLE
IEP-703 Fix HTTP response code inconsistencies

### DIFF
--- a/apispec/600-schema.yml
+++ b/apispec/600-schema.yml
@@ -311,7 +311,7 @@ paths:
       operationId: deleteAppointment
       summary: Delete the appointment resource
       responses:
-        200:
+        204:
           description: The appointment was deleted from this transaction
         400:
           description: Bad request.
@@ -375,7 +375,8 @@ components:
             validation_status:
               type: string
               format: uri
-              example: /transactions/{transaction_id}/insolvency/validation-status
+              example:
+                /transactions/{transaction_id}/insolvency/validation-status
 
     ValidationStatusResource:
       type: object
@@ -387,7 +388,9 @@ components:
             properties:
               error:
                 type: string
-                example: "error - if no practitioners are present then an attachment of the type resolution must be present"
+                example:
+                  "error - if no practitioners are present then an attachment of
+                  the type resolution must be present"
               location:
                 type: string
                 example: "no practitioners and no resolution"
@@ -518,7 +521,8 @@ components:
             self:
               type: string
               format: uri
-              example: /transactions/{transaction_id}/insolvency/liquidator/{practitioner_id}
+              example:
+                /transactions/{transaction_id}/insolvency/liquidator/{practitioner_id}
 
     AllPractitionerResources:
       type: array
@@ -542,16 +546,23 @@ components:
             self:
               type: string
               format: uri
-              example: /transactions/{transaction_id}/insolvency/practitioners/{practitioner_id}/appointment
+              example:
+                /transactions/{transaction_id}/insolvency/practitioners/{practitioner_id}/appointment
 
   securitySchemes:
     oauth2:
       type: oauth2
-      description: This API uses OAuth2 with the correct grants to allow insolvency data submission
+      description:
+        This API uses OAuth2 with the correct grants to allow insolvency data
+        submission
       flows:
         authorizationCode:
           tokenUrl: "https://api.companieshouse.gov.uk/oauth2/token"
           authorizationUrl: "https://api.companieshouse.gov.uk/oauth2/authorize"
           scopes:
-            https://identity.company-information.service.gov.uk/user/profile.read: User profile read permission required for Transaction API (not directly required for Insolvency API)
-            https://api.company-information.service.gov.uk/company/*/insolvency.write-full: Full Insolvency Practitioner permissions (all insolvency-related operations)
+            https://identity.company-information.service.gov.uk/user/profile.read:
+              User profile read permission required for Transaction API (not
+              directly required for Insolvency API)
+            https://api.company-information.service.gov.uk/company/*/insolvency.write-full:
+              Full Insolvency Practitioner permissions (all insolvency-related
+              operations)

--- a/apispec/schema.yml
+++ b/apispec/schema.yml
@@ -55,7 +55,7 @@ paths:
             schema:
               $ref: '#/components/schemas/AttachmentWritable'
       responses:
-        200:
+        201:
           description: The file was accepted for processing.
           content:
             application/json:
@@ -256,7 +256,7 @@ paths:
                     - company
                     - creditors
       responses:
-        200:
+        201:
           description: Practitioner appointment
           content:
             application/json:
@@ -312,7 +312,7 @@ paths:
       operationId: deleteAppointment
       summary: Delete the appointment resource
       responses:
-        200:
+        204:
           description: The appointment was deleted from this transaction
 
   /transactions/{transaction_id}/insolvency/statement-of-affairs:
@@ -336,7 +336,7 @@ paths:
             schema:
               $ref: '#/components/schemas/StatementOfAffairsWritable'
       responses:
-        200:
+        201:
           description: Statement of affairs created
           content:
             application/json:
@@ -427,7 +427,7 @@ paths:
             schema:
               $ref: '#/components/schemas/ResolutionResourceWritable'
       responses:
-        200:
+        201:
           description: The resolution details was sent successfully
           content:
             application/json:
@@ -452,7 +452,7 @@ paths:
           schema:
             type: string
       security:
-        - oauth2: [ submit_insolvency_data ]
+        - oauth2: [submit_insolvency_data]
       operationId: getResolution
       summary: Get the resolution resource
       responses:
@@ -515,7 +515,7 @@ paths:
             schema:
               $ref: '#/components/schemas/ProgressReportWritable'
       responses:
-        200:
+        201:
           description: Progress report created
           content:
             application/json:
@@ -541,7 +541,7 @@ paths:
           schema:
             type: string
       security:
-        - oauth2: [ submit_insolvency_data ]
+        - oauth2: [submit_insolvency_data]
       operationId: getProgressReport
       summary: Get the progress report resource
       responses:
@@ -568,7 +568,7 @@ paths:
           schema:
             type: string
       security:
-        - oauth2: [ submit_insolvency_data ]
+        - oauth2: [submit_insolvency_data]
       operationId: deleteProgressReport
       summary: Delete the progress report resource
       responses:
@@ -936,7 +936,9 @@ components:
   securitySchemes:
     oauth2:
       type: oauth2
-      description: This API uses OAuth2 with the correct grants to allow insolvency data submission
+      description:
+        This API uses OAuth2 with the correct grants to allow insolvency data
+        submission
       flows:
         authorizationCode:
           tokenUrl: "https://api.companieshouse.gov.uk/oauth2/token"

--- a/handlers/practitioner_resource.go
+++ b/handlers/practitioner_resource.go
@@ -332,16 +332,16 @@ func HandleGetPractitionerAppointment(svc dao.Service) http.Handler {
 			msg := fmt.Sprintf("practitionerID [%s] not found for transactionID [%s]", practitionerID, transactionID)
 			log.InfoR(req, msg)
 			m := models.NewMessageResponse(msg)
-			utils.WriteJSONWithStatus(w, req, m, http.StatusInternalServerError)
+			utils.WriteJSONWithStatus(w, req, m, http.StatusNotFound)
 			return
 		}
 
 		// Check if practitioner has an appointment
 		if practitioner.Appointment == nil {
-			msg := fmt.Sprintf("No appointment found for practitionerID [%s] an transactionID [%s]", practitionerID, transactionID)
+			msg := fmt.Sprintf("No appointment found for practitionerID [%s] and transactionID [%s]", practitionerID, transactionID)
 			log.InfoR(req, msg)
 			m := models.NewMessageResponse(msg)
-			utils.WriteJSONWithStatus(w, req, m, http.StatusInternalServerError)
+			utils.WriteJSONWithStatus(w, req, m, http.StatusNotFound)
 			return
 		}
 

--- a/handlers/practitioner_resource_test.go
+++ b/handlers/practitioner_resource_test.go
@@ -1388,7 +1388,8 @@ func TestUnitHandleGetPractitionerAppointment(t *testing.T) {
 		})
 		res := serveHandleGetPractitionerAppointment(body, mockService, true, true)
 
-		So(res.Code, ShouldEqual, http.StatusInternalServerError)
+		So(res.Code, ShouldEqual, http.StatusNotFound)
+		So(res.Body.String(), ShouldContainSubstring, "not found")
 	})
 
 	Convey("empty appointment returned", t, func() {
@@ -1404,7 +1405,8 @@ func TestUnitHandleGetPractitionerAppointment(t *testing.T) {
 		})
 		res := serveHandleGetPractitionerAppointment(body, mockService, true, true)
 
-		So(res.Code, ShouldEqual, http.StatusInternalServerError)
+		So(res.Code, ShouldEqual, http.StatusNotFound)
+		So(res.Body.String(), ShouldContainSubstring, "No appointment found")
 	})
 
 	Convey("success - appointment returned", t, func() {

--- a/handlers/progress_report_resource.go
+++ b/handlers/progress_report_resource.go
@@ -83,6 +83,6 @@ func HandleCreateProgressReport(svc dao.Service, helperService utils.HelperServi
 
 		log.InfoR(req, fmt.Sprintf("successfully added statement of progress report with transaction ID: %s, to mongo", transactionID))
 
-		utils.WriteJSONWithStatus(w, req, daoResponse, http.StatusOK)
+		utils.WriteJSONWithStatus(w, req, daoResponse, http.StatusCreated)
 	})
 }

--- a/handlers/progress_report_resource_test.go
+++ b/handlers/progress_report_resource_test.go
@@ -546,7 +546,8 @@ func TestUnitHandleCreateProgressReport(t *testing.T) {
 
 		res := serveHandleCreateProgressReport(body, mockService, mockHelperService, true, rec)
 
-		So(res.Code, ShouldEqual, http.StatusOK)
+		So(res.Code, ShouldEqual, http.StatusCreated)
+		So(res.Body.String(), ShouldContainSubstring, "\"kind\":\"insolvency-resource#progress-report\"")
 	})
 }
 

--- a/handlers/resolution_resource.go
+++ b/handlers/resolution_resource.go
@@ -91,7 +91,7 @@ func HandleCreateResolution(svc dao.Service, helperService utils.HelperService) 
 
 		log.InfoR(req, fmt.Sprintf("successfully added resolution resource with transaction ID: %s, to mongo", transactionID))
 
-		utils.WriteJSONWithStatus(w, req, daoResponse, http.StatusOK)
+		utils.WriteJSONWithStatus(w, req, daoResponse, http.StatusCreated)
 	})
 }
 

--- a/handlers/resolution_resource_test.go
+++ b/handlers/resolution_resource_test.go
@@ -374,7 +374,7 @@ func TestUnitHandleCreateResolution(t *testing.T) {
 
 		res := serveHandleCreateResolution(body, mockService, mockHelperService, true, rec)
 
-		So(res.Code, ShouldEqual, http.StatusOK)
+		So(res.Code, ShouldEqual, http.StatusCreated)
 		So(res.Body.String(), ShouldContainSubstring, "\"date_of_resolution\":\"2021-06-06\"")
 	})
 }

--- a/handlers/soa_resource.go
+++ b/handlers/soa_resource.go
@@ -83,7 +83,7 @@ func HandleCreateStatementOfAffairs(svc dao.Service, helperService utils.HelperS
 
 		log.InfoR(req, fmt.Sprintf("successfully added statement of affairs resource with transaction ID: %s, to mongo", transactionID))
 
-		utils.WriteJSONWithStatus(w, req, daoResponse, http.StatusOK)
+		utils.WriteJSONWithStatus(w, req, daoResponse, http.StatusCreated)
 	})
 }
 

--- a/handlers/soa_resource_test.go
+++ b/handlers/soa_resource_test.go
@@ -384,7 +384,8 @@ func TestUnitHandleCreateStatementOfAffairs(t *testing.T) {
 
 		res := serveHandleCreateStatementOfAffairs(body, mockService, mockHelperService, true, rec)
 
-		So(res.Code, ShouldEqual, http.StatusOK)
+		So(res.Code, ShouldEqual, http.StatusCreated)
+		So(res.Body.String(), ShouldContainSubstring, "\"statement_date\":\"2021-06-06\"")
 	})
 }
 


### PR DESCRIPTION
1) System fix only: Get practitioner appointment corrected to return 404 when the practitioner or appointment is not found
2) System fix + schema correction: Resolution, SoA & Progress report POST responses corrected to return 201
3) Schema corrections only: Attachment upload (success) returns 201, Appoint practitioner (success) returns 201, Delete practitioner appointment (success) returns 204.
Also made a few schema formatting tweaks (long lines & spaces in brackets) but left long lines that were due to urls (as inserting escape characters to allow the lines to split seemed less readable).