### PR TITLE
DELETE endpoint added for the LIQ03 progress report

### DIFF
--- a/dao/mongo.go
+++ b/dao/mongo.go
@@ -674,7 +674,7 @@ func (m *MongoService) GetStatementOfAffairsResource(transactionID string) (mode
 // DeleteStatementOfAffairsResource deletes the statement of affairs filed for an insolvency case
 func (m *MongoService) DeleteStatementOfAffairsResource(transactionID string) (int, error) {
 
-	httpStatus, err := m.DeleteResourceDBChecks(transactionID, "statement-of-affairs")
+	httpStatus, err := m.DeleteResource(transactionID, "statement-of-affairs")
 	return httpStatus, err
 
 }
@@ -764,7 +764,7 @@ func (m *MongoService) GetProgressReportResource(transactionID string) (*models.
 // DeleteProgressReportResource deletes the progress report filed for an insolvency case
 func (m *MongoService) DeleteProgressReportResource(transactionID string) (int, error) {
 
-	httpStatus, err := m.DeleteResourceDBChecks(transactionID, "progress-report")
+	httpStatus, err := m.DeleteResource(transactionID, "progress-report")
 	return httpStatus, err
 
 }
@@ -801,15 +801,15 @@ func (m *MongoService) GetResolutionResource(transactionID string) (models.Resol
 	return *insolvencyResource.Data.Resolution, nil
 }
 
-// DeleteResolutionResource deletes an resource filed for an Insolvency Case
+// DeleteResolutionResource deletes a resolution resource filed for an Insolvency Case
 func (m *MongoService) DeleteResolutionResource(transactionID string) (int, error) {
 
-	httpStatus, err := m.DeleteResourceDBChecks(transactionID, "resolution")
+	httpStatus, err := m.DeleteResource(transactionID, "resolution")
 	return httpStatus, err
 
 }
 
-func (m *MongoService) DeleteResourceDBChecks(transactionID string, resType string) (int, error) {
+func (m *MongoService) DeleteResource(transactionID string, resType string) (int, error) {
 	collection := m.db.Collection(m.CollectionName)
 
 	// Choose specific transaction for insolvency case with attachment to be removed

--- a/dao/mongo.go
+++ b/dao/mongo.go
@@ -675,7 +675,6 @@ func (m *MongoService) GetStatementOfAffairsResource(transactionID string) (mode
 func (m *MongoService) DeleteStatementOfAffairsResource(transactionID string) (int, error) {
 
 	httpStatus, err := m.DeleteResourceDBChecks(transactionID, "statement-of-affairs")
-
 	return httpStatus, err
 
 }
@@ -766,7 +765,6 @@ func (m *MongoService) GetProgressReportResource(transactionID string) (*models.
 func (m *MongoService) DeleteProgressReportResource(transactionID string) (int, error) {
 
 	httpStatus, err := m.DeleteResourceDBChecks(transactionID, "progress-report")
-
 	return httpStatus, err
 
 }
@@ -807,7 +805,6 @@ func (m *MongoService) GetResolutionResource(transactionID string) (models.Resol
 func (m *MongoService) DeleteResolutionResource(transactionID string) (int, error) {
 
 	httpStatus, err := m.DeleteResourceDBChecks(transactionID, "resolution")
-
 	return httpStatus, err
 
 }

--- a/dao/mongo_driver_test.go
+++ b/dao/mongo_driver_test.go
@@ -918,95 +918,6 @@ func TestUnitAddAttachmentToInsolvencyResourceDriver(t *testing.T) {
 	})
 }
 
-func TestUnitGetProgressReportResourceDriver(t *testing.T) {
-	t.Parallel()
-
-	mongoService, commandError, _, opts, _ := setDriverUp()
-
-	mt := mtest.New(t, opts)
-	defer mt.Close()
-
-	mt.Run("GetProgressReportResource runs successfully", func(mt *mtest.T) {
-		bsonprogressReport := bson.D{
-			{"from_date", "from_date"},
-			{"to_date", "to_date"},
-			 
-		}
-		bsonInsolvencyResourceDaoData := bson.D{
-			{"company_number", "company_number"},
-			{"case_type", "case_type"},
-			{"company_name", "company_name"},
-			{"progress-report", bsonprogressReport},
-		}
-
-		bsonLink := bson.D{
-			{"self", "self"},
-		}
-
-		bsonProgress := bson.D{
-			{"transaction_id", "transaction_id"},
-			{"attachments", "attachments"},
-			{"etag", "etag"},
-			{"kind", "kind"},
-			{"data", bsonInsolvencyResourceDaoData},
-			{"links", bsonLink},
-		}
-
-		mt.AddMockResponses(mtest.CreateCursorResponse(1, "models.ProgressReportResourceDao", mtest.FirstBatch, bsonProgress))
-
-		mongoService.db = mt.DB
-		progressReportResource, err := mongoService.GetProgressReportResource("transactionID")
-
-		assert.Nil(t, err)
-		assert.NotNil(t, progressReportResource)
-	})
-
-	mt.Run("GetProgressReportResource fails on wrong attachment", func(mt *mtest.T) {
-		bsonprogressReport := bson.D{
-			{"from_date", "from_date"},
-			{"to_date", "to_date"},
-			{"attachments", "attachments"},
-			 
-		}
-		bsonInsolvencyResourceDaoData := bson.D{
-			{"company_number", "company_number"},
-			{"case_type", "case_type"},
-			{"company_name", "company_name"},
-			{"progress-report", bsonprogressReport},
-		}
-
-		bsonLink := bson.D{
-			{"self", "self"},
-		}
-
-		bsonProgress := bson.D{
-			{"transaction_id", "transaction_id"},
-			{"attachments", "attachments"},
-			{"etag", "etag"},
-			{"kind", "kind"},
-			{"data", bsonInsolvencyResourceDaoData},
-			{"links", bsonLink},
-		}
-
-		mt.AddMockResponses(mtest.CreateCursorResponse(1, "models.ProgressReportResourceDao", mtest.FirstBatch, bsonProgress))
-
-		mongoService.db = mt.DB
-		progressReportResource, err := mongoService.GetProgressReportResource("transactionID")
-
-		assert.NotNil(t, err)
-		assert.NotNil(t, progressReportResource)
-	})
-
-	mt.Run("GetProgressReportResource runs with error", func(mt *mtest.T) {
-		mt.AddMockResponses(mtest.CreateCommandErrorResponse(commandError))
-
-		mongoService.db = mt.DB
-		_, err := mongoService.GetProgressReportResource("transactionID")
-
-		assert.Equal(t, err.Error(), "(Name) Message")
-	})
-}
-
 func TestUnitGetAttachmentResourcesDriver(t *testing.T) {
 	t.Parallel()
 
@@ -1678,6 +1589,203 @@ func TestUnitCreateProgressReportResourceDriver(t *testing.T) {
 
 		assert.Nil(t, err)
 		assert.Equal(t, code, 201)
+	})
+}
+
+func TestUnitGetProgressReportResourceDriver(t *testing.T) {
+	t.Parallel()
+
+	mongoService, commandError, _, opts, _ := setDriverUp()
+
+	mt := mtest.New(t, opts)
+	defer mt.Close()
+
+	mt.Run("GetProgressReportResource runs successfully", func(mt *mtest.T) {
+		bsonprogressReport := bson.D{
+			{"from_date", "from_date"},
+			{"to_date", "to_date"},
+			 
+		}
+		bsonInsolvencyResourceDaoData := bson.D{
+			{"company_number", "company_number"},
+			{"case_type", "case_type"},
+			{"company_name", "company_name"},
+			{"progress-report", bsonprogressReport},
+		}
+
+		bsonLink := bson.D{
+			{"self", "self"},
+		}
+
+		bsonProgress := bson.D{
+			{"transaction_id", "transaction_id"},
+			{"attachments", "attachments"},
+			{"etag", "etag"},
+			{"kind", "kind"},
+			{"data", bsonInsolvencyResourceDaoData},
+			{"links", bsonLink},
+		}
+
+		mt.AddMockResponses(mtest.CreateCursorResponse(1, "models.ProgressReportResourceDao", mtest.FirstBatch, bsonProgress))
+
+		mongoService.db = mt.DB
+		progressReportResource, err := mongoService.GetProgressReportResource("transactionID")
+
+		assert.Nil(t, err)
+		assert.NotNil(t, progressReportResource)
+	})
+
+	mt.Run("GetProgressReportResource fails on wrong attachment", func(mt *mtest.T) {
+		bsonprogressReport := bson.D{
+			{"from_date", "from_date"},
+			{"to_date", "to_date"},
+			{"attachments", "attachments"},
+			 
+		}
+		bsonInsolvencyResourceDaoData := bson.D{
+			{"company_number", "company_number"},
+			{"case_type", "case_type"},
+			{"company_name", "company_name"},
+			{"progress-report", bsonprogressReport},
+		}
+
+		bsonLink := bson.D{
+			{"self", "self"},
+		}
+
+		bsonProgress := bson.D{
+			{"transaction_id", "transaction_id"},
+			{"attachments", "attachments"},
+			{"etag", "etag"},
+			{"kind", "kind"},
+			{"data", bsonInsolvencyResourceDaoData},
+			{"links", bsonLink},
+		}
+
+		mt.AddMockResponses(mtest.CreateCursorResponse(1, "models.ProgressReportResourceDao", mtest.FirstBatch, bsonProgress))
+
+		mongoService.db = mt.DB
+		progressReportResource, err := mongoService.GetProgressReportResource("transactionID")
+
+		assert.NotNil(t, err)
+		assert.NotNil(t, progressReportResource)
+	})
+
+	mt.Run("GetProgressReportResource runs with error", func(mt *mtest.T) {
+		mt.AddMockResponses(mtest.CreateCommandErrorResponse(commandError))
+
+		mongoService.db = mt.DB
+		_, err := mongoService.GetProgressReportResource("transactionID")
+
+		assert.Equal(t, err.Error(), "(Name) Message")
+	})
+}
+
+func TestUnitDeleteProgressReportResourceDriver(t *testing.T) {
+	t.Parallel()
+
+	mongoService, commandError, expectedInsolvency, opts, _ := setDriverUp()
+
+	bsonData := bson.M{
+		"id":               "ID",
+		"ip_code":          "IPCode",
+		"first_name":       "FirstName",
+		"last_name":        "LastName",
+		"telephone_number": "TelephoneNumber",
+		"email":            "Email",
+	}
+
+	bsonArrays := bson.A{}
+	bsonArrays = append(bsonArrays, bsonData)
+	bsonInsolvency := bson.D{
+		{"company_number", "CompanyNumber"},
+		{"case_type", "CaseType"},
+		{"company_name", "CompanyName"},
+		{"practitioners", bsonArrays},
+	}
+
+	mt := mtest.New(t, opts)
+	defer mt.Close()
+
+	mt.Run("DeleteProgressReportResource runs with error", func(mt *mtest.T) {
+		mt.AddMockResponses(mtest.CreateCommandErrorResponse(commandError))
+
+		mongoService.db = mt.DB
+
+		_, err := mongoService.DeleteProgressReportResource("transactionID")
+
+		assert.Equal(t, err.Error(), "there was a problem handling your request for transaction id transactionID")
+	})
+
+	mt.Run("DeleteProgressReportResource runs with error on UpdateOne", func(mt *mtest.T) {
+		mt.AddMockResponses(mtest.CreateCursorResponse(1, "models.InsolvencyResourceDao", mtest.FirstBatch, bson.D{
+			{"_id", expectedInsolvency.ID},
+			{"transaction_id", expectedInsolvency.TransactionID},
+			{"etag", expectedInsolvency.Etag},
+			{"kind", expectedInsolvency.Kind},
+			{"data", bsonInsolvency},
+		}))
+
+		mt.AddMockResponses(mtest.CreateCommandErrorResponse(commandError))
+
+		mongoService.db = mt.DB
+		code, err := mongoService.DeleteProgressReportResource("transactionID")
+
+		assert.NotNil(t, err)
+		assert.Equal(t, err.Error(), "there was a problem handling your request for transaction id [transactionID] - could not delete progress report")
+		assert.Equal(t, code, 500)
+
+	})
+
+	mt.Run("DeleteProgressReportResource runs with zero ModifiedCount", func(mt *mtest.T) {
+		mt.AddMockResponses(mtest.CreateCursorResponse(1, "models.InsolvencyResourceDao", mtest.FirstBatch, bson.D{
+			{"_id", expectedInsolvency.ID},
+			{"transaction_id", expectedInsolvency.TransactionID},
+			{"etag", expectedInsolvency.Etag},
+			{"kind", expectedInsolvency.Kind},
+			{"data", bsonInsolvency},
+		}))
+
+		mt.AddMockResponses(mtest.CreateCommandErrorResponse(commandError))
+
+		mt.AddMockResponses(mtest.CreateSuccessResponse(
+			bson.E{Key: "n", Value: 1},
+			bson.E{Key: "nModified", Value: 0},
+			bson.E{Key: "upserted", Value: 1},
+		))
+
+		mongoService.db = mt.DB
+		code, err := mongoService.DeleteProgressReportResource("transactionID")
+
+		assert.NotNil(t, err)
+		assert.Equal(t, err.Error(), "there was a problem handling your request for transaction id [transactionID] - progress report not found")
+		assert.Equal(t, code, 404)
+
+	})
+
+	mt.Run("DeleteProgressReportResource runs successfully", func(mt *mtest.T) {
+		mt.AddMockResponses(mtest.CreateCursorResponse(1, "models.InsolvencyResourceDao", mtest.FirstBatch, bson.D{
+			{"_id", expectedInsolvency.ID},
+			{"transaction_id", expectedInsolvency.TransactionID},
+			{"etag", expectedInsolvency.Etag},
+			{"kind", expectedInsolvency.Kind},
+			{"data", bsonInsolvency},
+		}))
+
+		mt.AddMockResponses(mtest.CreateCommandErrorResponse(commandError))
+
+		mt.AddMockResponses(mtest.CreateSuccessResponse(
+			bson.E{Key: "n", Value: 1},
+			bson.E{Key: "nModified", Value: 1},
+			bson.E{Key: "upserted", Value: 1},
+		))
+
+		mongoService.db = mt.DB
+		code, err := mongoService.DeleteProgressReportResource("transactionID")
+
+		assert.Nil(t, err)
+		assert.Equal(t, code, 204)
+
 	})
 }
 

--- a/dao/mongo_test.go
+++ b/dao/mongo_test.go
@@ -271,6 +271,19 @@ func TestUnitGetProgressReportResource(t *testing.T) {
 	})
 }
 
+func TestUnitDeleteProgressReportResource(t *testing.T) {
+
+	Convey("Delete progress report", t, func() {
+
+		MongoService := setUp(t)
+
+		_, err := MongoService.DeleteProgressReportResource("transactionID")
+
+		So(err.Error(), ShouldEqual, "there was a problem handling your request for transaction id transactionID")
+		
+	})
+}
+
 func TestUnitGetResolutionResource(t *testing.T) {
 
 	Convey("Get resolution resource", t, func() {

--- a/dao/mongo_test.go
+++ b/dao/mongo_test.go
@@ -306,3 +306,14 @@ func TestUnitDeleteResolutionResource(t *testing.T) {
 		So(err.Error(), ShouldEqual, "there was a problem handling your request for transaction id transactionID")
 	})
 }
+
+func TestUnitDeleteResource(t *testing.T) {
+	Convey("DeleteResource", t, func() {
+
+		MongoService := setUp(t)
+
+		_, err := MongoService.DeleteResource("transactionID", "progress-report")
+
+		So(err.Error(), ShouldEqual, "there was a problem handling your request for transaction id transactionID")
+	})
+}

--- a/dao/service.go
+++ b/dao/service.go
@@ -69,6 +69,9 @@ type Service interface {
 
 	//GetProgressReportResource retrieves the progress report resource from an Insolvency case
 	GetProgressReportResource(transactionID string) (*models.ProgressReportResourceDao, error)
+
+	//DeleteProgressReportResource deletes a progress report for an insolvency case
+	DeleteProgressReportResource(transactionID string) (int, error)
 }
 
 // NewDAOService will create a new instance of the Service interface. All details about its implementation and the

--- a/handlers/progress_report_resource.go
+++ b/handlers/progress_report_resource.go
@@ -127,20 +127,13 @@ func HandleDeleteProgressReport(svc dao.Service, helperService utils.HelperServi
 
 		vars := mux.Vars(req)
 		transactionID := utils.GetTransactionIDFromVars(vars)
-		isTransactionValid, _ := helperService.HandleTransactionIdExistsValidation(w, req, transactionID)
-		if !isTransactionValid {
-			return
-		}
-
-		/*
 		if transactionID == "" {
 			log.ErrorR(req, fmt.Errorf("there is no transaction ID in the URL path"))
 			m := models.NewMessageResponse("transaction ID is not in the URL path")
 			utils.WriteJSONWithStatus(w, req, m, http.StatusBadRequest)
 			return
 		}
-		*/
-
+		
 		log.InfoR(req, fmt.Sprintf("start DELETE request for submit progress report with transaction id: %s", transactionID))
 
 		// Check if transaction is closed

--- a/handlers/progress_report_resource.go
+++ b/handlers/progress_report_resource.go
@@ -130,34 +130,6 @@ func HandleDeleteProgressReport(svc dao.Service, helperService utils.HelperServi
 			return
 		}
 
-		/*
-		vars := mux.Vars(req)
-		transactionID := utils.GetTransactionIDFromVars(vars)
-		if transactionID == "" {
-			log.ErrorR(req, fmt.Errorf("there is no transaction ID in the URL path"))
-			m := models.NewMessageResponse("transaction ID is not in the URL path")
-			utils.WriteJSONWithStatus(w, req, m, http.StatusBadRequest)
-			return
-		}
-		
-		log.InfoR(req, fmt.Sprintf("start DELETE request for submit progress report with transaction id: %s", transactionID))
-
-		// Check if transaction is closed
-		isTransactionClosed, err, httpStatus := service.CheckIfTransactionClosed(transactionID, req)
-		if err != nil {
-			log.ErrorR(req, fmt.Errorf("error checking transaction status for [%v]: [%s]", transactionID, err))
-			m := models.NewMessageResponse(fmt.Sprintf("error checking transaction status for [%v]: [%s]", transactionID, err))
-			utils.WriteJSONWithStatus(w, req, m, httpStatus)
-			return
-		}
-		if isTransactionClosed {
-			log.ErrorR(req, fmt.Errorf("transaction [%v] is already closed and cannot be updated", transactionID))
-			m := models.NewMessageResponse(fmt.Sprintf("transaction [%v] is already closed and cannot be updated", transactionID))
-			utils.WriteJSONWithStatus(w, req, m, httpStatus)
-			return
-		}
-		*/
-
 		// Delete progress report from DB
 		statusCode, err := svc.DeleteProgressReportResource(transactionID)
 		if err != nil {

--- a/handlers/progress_report_resource.go
+++ b/handlers/progress_report_resource.go
@@ -122,16 +122,24 @@ func HandleGetProgressReport(svc dao.Service) http.Handler {
 }
 
 // HandleDeleteProgressReport deletes a progress report resource from an insolvency case
-func HandleDeleteProgressReport(svc dao.Service) http.Handler {
+func HandleDeleteProgressReport(svc dao.Service, helperService utils.HelperService) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+
 		vars := mux.Vars(req)
 		transactionID := utils.GetTransactionIDFromVars(vars)
+		isTransactionValid, _ := helperService.HandleTransactionIdExistsValidation(w, req, transactionID)
+		if !isTransactionValid {
+			return
+		}
+
+		/*
 		if transactionID == "" {
 			log.ErrorR(req, fmt.Errorf("there is no transaction ID in the URL path"))
 			m := models.NewMessageResponse("transaction ID is not in the URL path")
 			utils.WriteJSONWithStatus(w, req, m, http.StatusBadRequest)
 			return
 		}
+		*/
 
 		log.InfoR(req, fmt.Sprintf("start DELETE request for submit progress report with transaction id: %s", transactionID))
 

--- a/handlers/progress_report_resource.go
+++ b/handlers/progress_report_resource.go
@@ -125,6 +125,12 @@ func HandleGetProgressReport(svc dao.Service) http.Handler {
 func HandleDeleteProgressReport(svc dao.Service, helperService utils.HelperService) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 
+		transactionID, isValidTransaction := utils.ValidateTransaction(helperService, req, w, "progress report", service.CheckIfTransactionClosed)
+		if !isValidTransaction {
+			return
+		}
+
+		/*
 		vars := mux.Vars(req)
 		transactionID := utils.GetTransactionIDFromVars(vars)
 		if transactionID == "" {
@@ -150,6 +156,7 @@ func HandleDeleteProgressReport(svc dao.Service, helperService utils.HelperServi
 			utils.WriteJSONWithStatus(w, req, m, httpStatus)
 			return
 		}
+		*/
 
 		// Delete progress report from DB
 		statusCode, err := svc.DeleteProgressReportResource(transactionID)

--- a/handlers/progress_report_resource_test.go
+++ b/handlers/progress_report_resource_test.go
@@ -646,6 +646,116 @@ func TestUnitHandleGetProgressReport(t *testing.T) {
 	})
 }
 
+func serveHandleDeleteProgressReport(service dao.Service, tranIDSet bool) *httptest.ResponseRecorder {
+	path := "/transactions/123456789/insolvency/progress-report"
+	req := httptest.NewRequest(http.MethodDelete, path, nil)
+	if tranIDSet {
+		req = mux.SetURLVars(req, map[string]string{"transaction_id": transactionID})
+	}
+	res := httptest.NewRecorder()
+
+	handler := HandleDeleteProgressReport(service)
+	handler.ServeHTTP(res, req)
+
+	return res
+}
+
+func TestUnitHandleDeleteProgressReport(t *testing.T) {
+	err := os.Chdir("..")
+	if err != nil {
+		log.ErrorR(nil, fmt.Errorf("error accessing root directory"))
+	}
+
+	Convey("Must need a transaction ID in the url", t, func() {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		res := serveHandleDeleteProgressReport(mock_dao.NewMockService(mockCtrl), false)
+
+		So(res.Code, ShouldEqual, http.StatusBadRequest)
+	})
+
+	Convey("Error checking if transaction is closed against transaction api", t, func() {
+		httpmock.Activate()
+		mockCtrl := gomock.NewController(t)
+		defer httpmock.DeactivateAndReset()
+		defer mockCtrl.Finish()
+
+		// Expect the transaction api to be called and return an error
+		httpmock.RegisterResponder(http.MethodGet, "https://api.companieshouse.gov.uk/transactions/12345678", httpmock.NewStringResponder(http.StatusInternalServerError, ""))
+
+		res := serveHandleDeleteProgressReport(mock_dao.NewMockService(mockCtrl), true)
+
+		So(res.Code, ShouldEqual, http.StatusInternalServerError)
+	})
+
+	Convey("Transaction is already closed and cannot be updated", t, func() {
+		httpmock.Activate()
+		mockCtrl := gomock.NewController(t)
+		defer httpmock.DeactivateAndReset()
+		defer mockCtrl.Finish()
+
+		// Expect the transaction api to be called and return an already closed transaction
+		httpmock.RegisterResponder(http.MethodGet, "https://api.companieshouse.gov.uk/transactions/12345678", httpmock.NewStringResponder(http.StatusOK, transactionProfileResponseClosed))
+
+		res := serveHandleDeleteProgressReport(mock_dao.NewMockService(mockCtrl), true)
+
+		So(res.Code, ShouldEqual, http.StatusForbidden)
+	})
+
+	Convey("Error when deleting progress report from DB", t, func() {
+		httpmock.Activate()
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+		defer httpmock.DeactivateAndReset()
+
+		// Expect the transaction api to be called and return an open transaction
+		httpmock.RegisterResponder(http.MethodGet, "https://api.companieshouse.gov.uk/transactions/12345678", httpmock.NewStringResponder(http.StatusOK, transactionProfileResponse))
+
+		mockService := mock_dao.NewMockService(mockCtrl)
+		mockService.EXPECT().DeleteProgressReportResource(transactionID).Return(http.StatusInternalServerError, fmt.Errorf("err"))
+
+		res := serveHandleDeleteProgressReport(mockService, true)
+
+		So(res.Code, ShouldEqual, http.StatusInternalServerError)
+	})
+
+	Convey("Progress report not found when deleting from DB", t, func() {
+		httpmock.Activate()
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+		defer httpmock.DeactivateAndReset()
+
+		// Expect the transaction api to be called and return an open transaction
+		httpmock.RegisterResponder(http.MethodGet, "https://api.companieshouse.gov.uk/transactions/12345678", httpmock.NewStringResponder(http.StatusOK, transactionProfileResponse))
+
+		mockService := mock_dao.NewMockService(mockCtrl)
+		mockService.EXPECT().DeleteProgressReportResource(transactionID).Return(http.StatusNotFound, fmt.Errorf("err"))
+
+		res := serveHandleDeleteProgressReport(mockService, true)
+
+		So(res.Code, ShouldEqual, http.StatusNotFound)
+	})
+
+	Convey("Successfully delete progress report from DB", t, func() {
+		httpmock.Activate()
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+		defer httpmock.DeactivateAndReset()
+
+		// Expect the transaction api to be called and return an open transaction
+		httpmock.RegisterResponder(http.MethodGet, "https://api.companieshouse.gov.uk/transactions/12345678", httpmock.NewStringResponder(http.StatusOK, transactionProfileResponse))
+
+		mockService := mock_dao.NewMockService(mockCtrl)
+		mockService.EXPECT().DeleteProgressReportResource(transactionID).Return(http.StatusNoContent, nil)
+
+		res := serveHandleDeleteProgressReport(mockService, true)
+
+		So(res.Code, ShouldEqual, http.StatusNoContent)
+	})
+
+}
+
 func generateProgressReport() models.ProgressReport {
 	return models.ProgressReport{
 		FromDate: "2021-06-06",

--- a/handlers/register.go
+++ b/handlers/register.go
@@ -70,6 +70,7 @@ func Register(mainRouter *mux.Router, svc dao.Service, helperService utils.Helpe
 
 		publicAppRouter.Handle("/{transaction_id}/insolvency/progress-report", HandleCreateProgressReport(svc, helperService)).Methods(http.MethodPost).Name("createProgressReport")
 		publicAppRouter.Handle("/{transaction_id}/insolvency/progress-report", HandleGetProgressReport(svc)).Methods(http.MethodGet).Name("getProgressReport")
+		publicAppRouter.Handle("/{transaction_id}/insolvency/progress-report", HandleDeleteProgressReport(svc)).Methods(http.MethodDelete).Name("deleteProgressReport")
 	} else {
 		log.Info("Non-live endpoints blocked")
 	}

--- a/handlers/register.go
+++ b/handlers/register.go
@@ -70,7 +70,7 @@ func Register(mainRouter *mux.Router, svc dao.Service, helperService utils.Helpe
 
 		publicAppRouter.Handle("/{transaction_id}/insolvency/progress-report", HandleCreateProgressReport(svc, helperService)).Methods(http.MethodPost).Name("createProgressReport")
 		publicAppRouter.Handle("/{transaction_id}/insolvency/progress-report", HandleGetProgressReport(svc)).Methods(http.MethodGet).Name("getProgressReport")
-		publicAppRouter.Handle("/{transaction_id}/insolvency/progress-report", HandleDeleteProgressReport(svc)).Methods(http.MethodDelete).Name("deleteProgressReport")
+		publicAppRouter.Handle("/{transaction_id}/insolvency/progress-report", HandleDeleteProgressReport(svc, helperService)).Methods(http.MethodDelete).Name("deleteProgressReport")
 	} else {
 		log.Info("Non-live endpoints blocked")
 	}

--- a/mocks/helper_service_mock.go
+++ b/mocks/helper_service_mock.go
@@ -1,10 +1,11 @@
 package mocks
 
 import (
-	"github.com/jarcoal/httpmock"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/jarcoal/httpmock"
 
 	reflect "reflect"
 
@@ -144,6 +145,19 @@ func (m *MockHelperService) HandleCreateResourceValidation(w http.ResponseWriter
 	ret := m.ctrl.Call(m, "HandleCreateResourceValidation", w, req, err, httpStatus)
 	ret0, _ := ret[0].(bool)
 	return ret0
+}
+
+// HandleCreateResourceValidation indicates an expected call of HandleCreateResourceValidation
+func (mr *MockHelperServiceMockRecorder) HandleDeleteResourceValidation(w, req, resourceType interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleDeleteResourceValidation", reflect.TypeOf((*MockHelperService)(nil).HandleDeleteResourceValidation), w, req, resourceType)
+}
+
+// HandleCreateResourceValidation mocks base method
+func (m *MockHelperService) HandleDeleteResourceValidation(w http.ResponseWriter, req *http.Request, resourceType string) (bool, string) {
+	ret := m.ctrl.Call(m, "HandleCreateResourceValidation", w, req, resourceType)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(string)
+	return ret0, ret1
 }
 
 func CreateTestObjects(t *testing.T) (*MockService, *MockHelperService, *httptest.ResponseRecorder) {

--- a/mocks/service_mock.go
+++ b/mocks/service_mock.go
@@ -230,6 +230,19 @@ func (m *MockService) CreateProgressReportResource(dao *models.ProgressReportRes
 	return ret0, ret1
 }
 
+// DeleteProgressReportResource
+func (m *MockService) DeleteProgressReportResource(transactionID string) (int, error) {
+	ret := m.ctrl.Call(m, "DeleteProgressReportResource", transactionID)
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteProgressReportResource indicates an expected call of DeleteProgressReportResource
+func (mr *MockServiceMockRecorder) DeleteProgressReportResource(transactionID interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteProgressReportResource", reflect.TypeOf((*MockService)(nil).DeleteProgressReportResource), transactionID)
+}
+
 // CreateStatementOfAffairsResource indicates an expected call of CreateStatementOfAffairsResource
 func (mr *MockServiceMockRecorder) CreateStatementOfAffairsResource(dao, transactionID interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateStatementOfAffairsResource", reflect.TypeOf((*MockService)(nil).CreateStatementOfAffairsResource), dao, transactionID)

--- a/utils/validator.go
+++ b/utils/validator.go
@@ -62,7 +62,9 @@ func ValidateTransaction(helperService HelperService, req *http.Request, res htt
 		return transactionID, isValidTransaction
 	}
 
-	log.InfoR(req, fmt.Sprintf("start POST request for submit "+startMessage+"with transaction id: %s", transactionID))
+	reqMethod := req.Method
+
+	log.InfoR(req, fmt.Sprintf("start %s request for submit "+startMessage+" with transaction id: %s", reqMethod, transactionID))
 
 	// Check if transaction is checkIfTransactionClosedFn
 	var isTransactionClosed, err, httpStatus = checkIfTransactionClosedFn(transactionID, req)


### PR DESCRIPTION
Added new HandleDeleteProgressReport function.
Refactored mongo.go checks for deleting a resolution/statement-of-affairs/progress-report resource