### PR TITLE
Only put relevant attachments in filings [IEP-690]

### DIFF
--- a/handlers/insolvency_resource_test.go
+++ b/handlers/insolvency_resource_test.go
@@ -653,6 +653,12 @@ func TestUnitHandleGetFilings(t *testing.T) {
 
 		insolvencyCase := createInsolvencyResource()
 		insolvencyCase.Data.Practitioners = []models.PractitionerResourceDao{}
+		insolvencyCase.Data.Resolution = &models.ResolutionResourceDao{
+			DateOfResolution: "2021-06-06",
+			Attachments: []string{
+				"1234",
+			},
+		}
 		insolvencyCase.Data.Attachments = []models.AttachmentResourceDao{{
 			Type: "resolution",
 		}}
@@ -668,7 +674,7 @@ func TestUnitHandleGetFilings(t *testing.T) {
 		So(res.Body.String(), ShouldContainSubstring, `"company_number":"01234567"`)
 		So(res.Body.String(), ShouldContainSubstring, `"kind":"insolvency#LRESEX"`)
 		So(res.Body.String(), ShouldContainSubstring, `"Type":"resolution"`)
-		So(res.Body.String(), ShouldContainSubstring, `"practitioners":[]`)
+		So(res.Body.String(), ShouldNotContainSubstring, "practitioners")
 	})
 
 	Convey(`Generate filing for LIQ02 case with one practitioner and "statement-of-affairs-director"`, t, func() {
@@ -683,6 +689,12 @@ func TestUnitHandleGetFilings(t *testing.T) {
 
 		insolvencyCase := createInsolvencyResource()
 		insolvencyCase.Data.Practitioners[0].Appointment = nil
+		insolvencyCase.Data.StatementOfAffairs = &models.StatementOfAffairsResourceDao{
+			StatementDate: "2012-01-23",
+			Attachments: []string{
+				"123456789",
+			},
+		}
 		insolvencyCase.Data.Attachments = []models.AttachmentResourceDao{{
 			Type: "statement-of-affairs-director",
 		}}


### PR DESCRIPTION
Generated filing blocks now only include relevant attachments:
- LRESEX: "resolution"
- LIQ02: "statement-of-affairs-director", "statement-of-affairs-liquidator", "statement-of-concurrence":
- LIQ03: "progress-report"

Other data now also only included if relevant to filing type:
- case date only in LRESEX
- soa date only in LIQ02
- from & to dates only in LIQ03
- practitioners in 600, LIQ02 & LIQ03 but not LRESEX

Added additional checks to existing tests to confirm e.g. number & type of attachments in each generated filing block.

Updated one test to replace a check for empty practitioner block with the absence of a practitioner block to reflect changes.

For 2 test scenarios that used both statement-of-affairs-director & statement-of-affairs-liquidator (which cannot actually be submitted together) replaced this with the valid combination of statement-of-affairs-director & statement-of-concurrence.

Also did some minor tidying in edited files (inverted boolean checks, redundant function calls, return value ordering, whitespace).