### PR TITLE
fix: missing forward slash in selfLink (progress report)

### DIFF
--- a/transformers/progress_report_resource.go
+++ b/transformers/progress_report_resource.go
@@ -25,7 +25,7 @@ func ProgressReportResourceRequestToDB(req *models.ProgressReport, transactionID
 		return nil
 	}
 
-	selfLink := fmt.Sprintf(constants.TransactionsPath + transactionID + "insolvency/progress-report")
+	selfLink := fmt.Sprintf(constants.TransactionsPath + transactionID + "/insolvency/progress-report")
 
 	dao := &models.ProgressReportResourceDao{
 		FromDate:    req.FromDate,


### PR DESCRIPTION
Missing a forward slash in the selfLink item on POST response for progress report:
{
    "from_date": "2021-06-14",
    "to_date": "2022-06-13",
    "attachments": [
        "bda65619-916f-4ce8-9ebb-85d8add6576b"
    ],
    "etag": "7159403d0996851d33bd6f14cbae7132c87a833ea921c5718a9e440f",
    "kind": "insolvency-resource#progress-report",
    "links": {
        "self": "/transactions/040351-322416-777491insolvency/progress-report"
    }
}