### PR TITLE
add logics to delete practitioners

### DIFF
--- a/dao/mongo.go
+++ b/dao/mongo.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/companieshouse/chs.go/log"
@@ -391,9 +392,11 @@ func (m *MongoService) DeletePractitionerAppointment(transactionID string, pract
 		return http.StatusNotFound, fmt.Errorf("there was a problem handling your request for transaction id %s - no practitioner's appointment found", transactionID)
 	}
 
-	// check if practitionerID exists
-	_, isPresent := mappedPractitionerAppointment[practitionerID]
-	if isPresent {
+	// check if practitionerID exists and validate transactionID
+	value, isPresent := mappedPractitionerAppointment[practitionerID]
+	hasValidTransactionID := strings.Contains(value, transactionID)
+
+	if isPresent && hasValidTransactionID {
 		// remove unwanted appointment from the slice
 		delete(mappedPractitionerAppointment, practitionerID)
 

--- a/dao/mongo.go
+++ b/dao/mongo.go
@@ -317,7 +317,7 @@ func (m *MongoService) DeletePractitioner(practitionerID string, transactionID s
 			return statusCode, fmt.Errorf("there was a problem handling your request for transaction id %s - not able to update insolvency practitioners %s", transactionID, practitionerID)
 		}
 	} else {
-		return http.StatusForbidden, fmt.Errorf("there was a problem handling your request for transaction id %s not able to find practitioner %s to delete", transactionID, practitionerID)
+		return http.StatusNotFound, fmt.Errorf("there was a problem handling your request for transaction id %s not able to find practitioner %s to delete", transactionID, practitionerID)
 	}
 
 	return http.StatusNoContent, nil
@@ -358,7 +358,7 @@ func (m *MongoService) UpdatePractitionerAppointment(appointmentResourceDao *mod
 // DeletePractitionerAppointment deletes an appointment for the specified transactionID and practitionerID
 func (m *MongoService) DeletePractitionerAppointment(transactionID string, practitionerID string) (int, error) {
 
-	var pratitionerDocumentToUpdate primitive.M
+	var practitionerDocumentToUpdate primitive.M
 	var practitionerResourceDao models.PractitionerResourceDao
 
 	practitionerCollection := m.db.Collection(PractitionerCollectionName)
@@ -388,7 +388,7 @@ func (m *MongoService) DeletePractitionerAppointment(transactionID string, pract
 	mappedPractitionerAppointment, _, err := utils.ConvertStringToMapObjectAndStringList(practitionerResourceDao.Data.Links.Appointment)
 	if err != nil {
 		log.Error(err)
-		return http.StatusBadRequest, fmt.Errorf("there was a problem handling your request for transaction id %s - no practitioner's appointment found", transactionID)
+		return http.StatusNotFound, fmt.Errorf("there was a problem handling your request for transaction id %s - no practitioner's appointment found", transactionID)
 	}
 
 	// check if practitionerID exists
@@ -410,18 +410,18 @@ func (m *MongoService) DeletePractitionerAppointment(transactionID string, pract
 
 		practitionerToUpdate := bson.M{"data.practitioner_id": practitionerID}
 		if practitionerAppointmentString == "{}" {
-			pratitionerDocumentToUpdate = bson.M{"$unset": bson.M{"data.links.appointment": ""}}
+			practitionerDocumentToUpdate = bson.M{"$unset": bson.M{"data.links.appointment": ""}}
 		} else {
-			pratitionerDocumentToUpdate = bson.M{"$set": bson.M{"data.links.appointment": practitionerAppointmentString}}
+			practitionerDocumentToUpdate = bson.M{"$set": bson.M{"data.links.appointment": practitionerAppointmentString}}
 		}
 
-		statusCode, err := updateCollection(practitionerToUpdate, pratitionerDocumentToUpdate, practitionerCollection)
+		statusCode, err := updateCollection(practitionerToUpdate, practitionerDocumentToUpdate, practitionerCollection)
 		if err != nil {
 			log.Error(err)
 			return statusCode, fmt.Errorf("there was a problem handling your request for transaction id %s - not able to update insolvency practitioners %s", transactionID, practitionerID)
 		}
 	} else {
-		return http.StatusForbidden, fmt.Errorf("there was a problem handling your request for transaction id %s - not able to find practitioner %s to delete appointment", transactionID, practitionerID)
+		return http.StatusNotFound, fmt.Errorf("there was a problem handling your request for transaction id %s - not able to find practitioner %s to delete appointment", transactionID, practitionerID)
 	}
 
 	return http.StatusNoContent, nil

--- a/dao/mongo.go
+++ b/dao/mongo.go
@@ -352,10 +352,9 @@ func (m *MongoService) DeletePractitionerAppointment(transactionID string, pract
 	practitionerCollection := m.db.Collection(PractitionerCollectionName)
 	appointmentCollection := m.db.Collection(AppointmentCollectionName)
 
-	// Choose specific transaction for insolvency case with practitioner to be removed
+	// get practitioner with specified practitionerID
 	filter := bson.M{"data.practitioner_id": practitionerID}
 
-	// Check if insolvency case exists for specified transactionID
 	storedPractitioners := practitionerCollection.FindOne(context.Background(), filter)
 	err := storedPractitioners.Err()
 	if err != nil {

--- a/dao/mongo_driver_test.go
+++ b/dao/mongo_driver_test.go
@@ -450,8 +450,45 @@ func TestUnitDeletePractitionerDriver(t *testing.T) {
 		mongoService.db = mt.DB
 		code, err := mongoService.DeletePractitioner("practitionerID", "transactionID")
 
-		assert.Equal(t, code, 500)
-		assert.Equal(t, err.Error(), "there was a problem handling your request for transaction id transactionID not able to map insolvency practitioners")
+		assert.Equal(t, code, 400)
+		assert.Equal(t, err.Error(), "there was a problem handling your request for transaction id transactionID no insolvency practitioners found")
+	})
+
+	mt.Run("DeletePractitioner run successfully with incorrect practitionerID", func(mt *mtest.T) {
+		mt.AddMockResponses(mtest.CreateCursorResponse(1, "models.InsolvencyResourceDao", mtest.FirstBatch, bson.D{
+			{"_id", expectedInsolvency.ID},
+			{"transaction_id", expectedInsolvency.TransactionID},
+			{"etag", expectedInsolvency.Data.Etag},
+			{"kind", expectedInsolvency.Data.Kind},
+			{"data", bsonInsolvency},
+		}))
+
+		mt.AddMockResponses(mtest.CreateCommandErrorResponse(commandError))
+
+		mt.AddMockResponses(bson.D{{"ok", 1}, {"acknowledged", true}, {"n", 1}})
+
+		mt.AddMockResponses(bson.D{
+			{"ok", 1},
+			{"value", bson.D{
+				{"_id", expectedInsolvency.ID},
+				{"transaction_id", expectedInsolvency.TransactionID},
+				{"etag", expectedInsolvency.Data.Etag},
+				{"kind", expectedInsolvency.Data.Kind},
+				{"data", bsonInsolvency},
+			}},
+		})
+
+		mt.AddMockResponses(bson.D{
+			{"ok", 1},
+			{"nModified", 1},
+		})
+
+		mongoService.db = mt.DB
+		code, err := mongoService.DeletePractitioner("VM04221441", "transactionID")
+
+		assert.Nil(t, err)
+		assert.Equal(t, code, 204)
+
 	})
 
 	mt.Run("DeletePractitioner run successfully with ModifiedCount", func(mt *mtest.T) {
@@ -484,7 +521,7 @@ func TestUnitDeletePractitionerDriver(t *testing.T) {
 		})
 
 		mongoService.db = mt.DB
-		code, err := mongoService.DeletePractitioner("practitionerID", "transactionID")
+		code, err := mongoService.DeletePractitioner("VM04221441", "transactionID")
 
 		assert.Nil(t, err)
 		assert.Equal(t, code, 204)
@@ -521,10 +558,10 @@ func TestUnitDeletePractitionerDriver(t *testing.T) {
 		})
 
 		mongoService.db = mt.DB
-		code, err := mongoService.DeletePractitioner("practitionerID", "transactionID")
+		code, err := mongoService.DeletePractitioner("VM04221441", "transactionID")
 
 		assert.NotNil(t, err)
-		assert.Equal(t, err.Error(), "there was a problem handling your request for transaction id transactionID - not able to update insolvency practitioners practitionerID")
+		assert.Equal(t, err.Error(), "there was a problem handling your request for transaction id transactionID - not able to update insolvency practitioners VM04221441")
 		assert.Equal(t, code, 404)
 
 	})
@@ -546,7 +583,7 @@ func TestUnitDeletePractitionerDriver(t *testing.T) {
 		})
 
 		mongoService.db = mt.DB
-		code, err := mongoService.DeletePractitioner("practitionerID", "transactionID")
+		code, err := mongoService.DeletePractitioner("VM04221441", "transactionID")
 
 		assert.NotNil(t, err)
 		assert.Equal(t, err.Error(), "there was a problem handling your request for transaction id transactionID not able to delete practitioners")
@@ -568,7 +605,7 @@ func TestUnitDeletePractitionerDriver(t *testing.T) {
 		mt.AddMockResponses(bson.D{{"ok", 0}, {"acknowledged", true}, {"n", 0}})
 
 		mongoService.db = mt.DB
-		code, err := mongoService.DeletePractitioner("practitionerID", "transactionID")
+		code, err := mongoService.DeletePractitioner("VM04221441", "transactionID")
 
 		assert.NotNil(t, err)
 		assert.Equal(t, err.Error(), "there was a problem handling your request for transaction id transactionID not able to delete practitioners appointment")
@@ -665,10 +702,10 @@ func TestUnitDeletePractitionerAppointmentDriver(t *testing.T) {
 		}))
 
 		mongoService.db = mt.DB
-		code, err := mongoService.DeletePractitionerAppointment("practitionerID", "transactionID")
+		code, err := mongoService.DeletePractitionerAppointment("transactionID", "practitionerID")
 
-		assert.Equal(t, code, 500)
-		assert.Equal(t, err.Error(), "there was a problem handling your request for transaction id practitionerID not able to map practitioner appointment")
+		assert.Equal(t, code, 400)
+		assert.Equal(t, err.Error(), "there was a problem handling your request for transaction id transactionID - no practitioner's appointment found")
 	})
 
 	mt.Run("DeletePractitionerAppointment run successfully with ModifiedCount", func(mt *mtest.T) {
@@ -712,7 +749,7 @@ func TestUnitDeletePractitionerAppointmentDriver(t *testing.T) {
 		})
 
 		mongoService.db = mt.DB
-		code, err := mongoService.DeletePractitionerAppointment("practitionerID", "transactionID")
+		code, err := mongoService.DeletePractitionerAppointment("transactionID", "VM04221441")
 
 		assert.Nil(t, err)
 		assert.Equal(t, code, 204)
@@ -762,10 +799,10 @@ func TestUnitDeletePractitionerAppointmentDriver(t *testing.T) {
 		})
 
 		mongoService.db = mt.DB
-		code, err := mongoService.DeletePractitionerAppointment("practitionerID", "transactionID")
+		code, err := mongoService.DeletePractitionerAppointment("transactionID", "VM04221441")
 
 		assert.NotNil(t, err)
-		assert.Equal(t, err.Error(), "there was a problem handling your request for transaction id practitionerID - not able to update insolvency practitioners transactionID")
+		assert.Equal(t, err.Error(), "there was a problem handling your request for transaction id transactionID - not able to update insolvency practitioners VM04221441")
 		assert.Equal(t, code, 404)
 
 	})
@@ -795,10 +832,10 @@ func TestUnitDeletePractitionerAppointmentDriver(t *testing.T) {
 		mt.AddMockResponses(bson.D{{"ok", 1}, {"acknowledged", true}, {"n", 0}})
 
 		mongoService.db = mt.DB
-		code, err := mongoService.DeletePractitionerAppointment("practitionerID", "transactionID")
+		code, err := mongoService.DeletePractitionerAppointment("transactionID", "VM04221441")
 
 		assert.NotNil(t, err)
-		assert.Equal(t, err.Error(), "there was a problem handling your request for transaction id practitionerID not able to delete practitioners appointment")
+		assert.Equal(t, err.Error(), "there was a problem handling your request for transaction id transactionID - not able to delete practitioners appointment")
 		assert.Equal(t, code, 500)
 
 	})
@@ -821,10 +858,10 @@ func TestUnitDeletePractitionerAppointmentDriver(t *testing.T) {
 		mt.AddMockResponses(mtest.CreateCommandErrorResponse(commandError))
 
 		mongoService.db = mt.DB
-		code, err := mongoService.DeletePractitionerAppointment("practitionerID", "transactionID")
+		code, err := mongoService.DeletePractitionerAppointment("transactionID", "practitionerID")
 
 		assert.NotNil(t, err)
-		assert.Equal(t, err.Error(), "there was a problem handling your request for transaction id practitionerID")
+		assert.Equal(t, err.Error(), "there was a problem handling your request for transaction id transactionID")
 		assert.Equal(t, code, 500)
 
 	})

--- a/dao/mongo_driver_test.go
+++ b/dao/mongo_driver_test.go
@@ -749,7 +749,7 @@ func TestUnitDeletePractitionerAppointmentDriver(t *testing.T) {
 		})
 
 		mongoService.db = mt.DB
-		code, err := mongoService.DeletePractitionerAppointment("transactionID", "VM04221441")
+		code, err := mongoService.DeletePractitionerAppointment("168570-809316-704268", "VM04221441")
 
 		assert.Nil(t, err)
 		assert.Equal(t, code, 204)
@@ -799,10 +799,10 @@ func TestUnitDeletePractitionerAppointmentDriver(t *testing.T) {
 		})
 
 		mongoService.db = mt.DB
-		code, err := mongoService.DeletePractitionerAppointment("transactionID", "VM04221441")
+		code, err := mongoService.DeletePractitionerAppointment("168570-809316-704268", "VM04221441")
 
 		assert.NotNil(t, err)
-		assert.Equal(t, err.Error(), "there was a problem handling your request for transaction id transactionID - not able to update insolvency practitioners VM04221441")
+		assert.Equal(t, err.Error(), "there was a problem handling your request for transaction id 168570-809316-704268 - not able to update insolvency practitioners VM04221441")
 		assert.Equal(t, code, 404)
 
 	})
@@ -832,10 +832,10 @@ func TestUnitDeletePractitionerAppointmentDriver(t *testing.T) {
 		mt.AddMockResponses(bson.D{{"ok", 1}, {"acknowledged", true}, {"n", 0}})
 
 		mongoService.db = mt.DB
-		code, err := mongoService.DeletePractitionerAppointment("transactionID", "VM04221441")
+		code, err := mongoService.DeletePractitionerAppointment("168570-809316-704268", "VM04221441")
 
 		assert.NotNil(t, err)
-		assert.Equal(t, err.Error(), "there was a problem handling your request for transaction id transactionID - not able to delete practitioners appointment")
+		assert.Equal(t, err.Error(), "there was a problem handling your request for transaction id 168570-809316-704268 - not able to delete practitioners appointment")
 		assert.Equal(t, code, 500)
 
 	})

--- a/dao/mongo_driver_test.go
+++ b/dao/mongo_driver_test.go
@@ -704,7 +704,7 @@ func TestUnitDeletePractitionerAppointmentDriver(t *testing.T) {
 		mongoService.db = mt.DB
 		code, err := mongoService.DeletePractitionerAppointment("transactionID", "practitionerID")
 
-		assert.Equal(t, code, 400)
+		assert.Equal(t, code, 404)
 		assert.Equal(t, err.Error(), "there was a problem handling your request for transaction id transactionID - no practitioner's appointment found")
 	})
 

--- a/dao/mongo_helper.go
+++ b/dao/mongo_helper.go
@@ -10,18 +10,33 @@ import (
 	"github.com/companieshouse/insolvency-api/utils"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo"
+	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
 //updateCollection updates documents of collections
-func updateCollection(transactionID string, practitionerID string, filter bson.M, updateDocument bson.M, collection *mongo.Collection) (int, error) {
-	_, err := collection.UpdateOne(context.Background(), filter, updateDocument)
+func updateCollection(filter bson.M, updateDocument bson.M, collection *mongo.Collection) (int, error) {
+	update, err := collection.UpdateOne(context.Background(), filter, updateDocument)
 	if err != nil {
-		errMsg := fmt.Errorf("could not update practitioner appointment for practitionerID %s: %s", practitionerID, err)
-		log.Error(errMsg)
-		return http.StatusInternalServerError, errMsg
+		return http.StatusInternalServerError, err
+	}
+
+	// Return error if Mongo could not update the document
+	if update.ModifiedCount == 0 {
+		err = fmt.Errorf("failed to update collection")
+		return http.StatusNotFound, err
 	}
 
 	return http.StatusNoContent, nil
+}
+
+//delete from Collection
+func deleteCollection(practitionerID string, filter bson.M, collection *mongo.Collection) (*mongo.DeleteResult, error) {
+	opts := options.Delete().SetHint(bson.M{"_id": 1})
+	result, err := collection.DeleteMany(context.TODO(), filter, opts)
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
 }
 
 func getInsolvencyPractitionersDetails(practitionersString string, transactionID string, collection *mongo.Collection) ([]models.PractitionerResourceDao, error) {
@@ -32,16 +47,16 @@ func getInsolvencyPractitionersDetails(practitionersString string, transactionID
 
 	// make a call to fetch all practitioners from the string array
 	var practitionerResourceDao []models.PractitionerResourceDao
-	practitionerResourceDao, err = getPractitioners(practitionerIDs, transactionID, collection)
+	practitionerResourceDao, err = getPractitioners(practitionerIDs, collection)
 	if err != nil {
-		log.Error(err)
+		log.Debug(err.Error(), log.Data{"transaction_id": transactionID})
 		return nil, err
 	}
 
 	return practitionerResourceDao, nil
 }
 
-func getPractitioners(practitionerIDs []string, transactionID string, collection *mongo.Collection) ([]models.PractitionerResourceDao, error) {
+func getPractitioners(practitionerIDs []string, collection *mongo.Collection) ([]models.PractitionerResourceDao, error) {
 	var practitionerResourceDaos []models.PractitionerResourceDao
 	var practitionerResourceDao models.PractitionerResourceDao
 
@@ -52,15 +67,14 @@ func getPractitioners(practitionerIDs []string, transactionID string, collection
 	// Retrieve practitioners and appointments from DB
 	practitionerCursor, err := collection.Aggregate(context.Background(), mongo.Pipeline{lookupQuery, matchQuery, unwindQuery})
 	if err != nil {
-		log.Debug("no practitioner found for transaction id", log.Data{"transaction_id": transactionID})
 		return nil, err
 	}
 
 	for practitionerCursor.Next(context.Background()) {
 		err := practitionerCursor.Decode(&practitionerResourceDao)
 		if err != nil {
-			log.Debug("error decoding practitioners", log.Data{"transaction_id": transactionID})
-			return nil, err
+			errMsg := fmt.Errorf("error decoding models")
+			return nil, errMsg
 		}
 
 		practitionerResourceDaos = append(practitionerResourceDaos, practitionerResourceDao)

--- a/dao/mongo_test.go
+++ b/dao/mongo_test.go
@@ -83,15 +83,15 @@ func TestUnitGetInsolvencyPractitionerByTransactionID(t *testing.T) {
 	})
 }
 
-func TestUnitGetPractitionersByIds(t *testing.T) {
+func TestUnitGetPractitionersResource(t *testing.T) {
 
 	Convey("Get practitioner resources", t, func() {
 
 		mongoService := setUp(t)
 
-		_, err := mongoService.GetPractitionersResource([]string{"practitionerID"}, "transactionID")
+		_, err := mongoService.GetPractitionersResource([]string{"practitionerID"})
 
-		So(err.Error(), ShouldEqual, "the Aggregate operation must have a Deployment set before Execute can be called")
+		So(err.Error(), ShouldEqual, "no practitioner found for practitioner id(s) [practitionerID]")
 	})
 }
 
@@ -115,7 +115,7 @@ func TestUnitDeletePractitionerAppointment(t *testing.T) {
 
 		_, err := mongoService.DeletePractitionerAppointment("transactionID", "practitionerID")
 
-		So(err.Error(), ShouldEqual, "could not update practitioner appointment for practitionerID practitionerID: the Update operation must have a Deployment set before Execute can be called")
+		So(err.Error(), ShouldEqual, "there was a problem handling your request for transaction id transactionID")
 	})
 }
 

--- a/dao/service.go
+++ b/dao/service.go
@@ -24,7 +24,7 @@ type Service interface {
 	GetPractitionerAppointment(practitionerID string, transactionID string) (*models.AppointmentResourceDao, error)
 
 	// GetPractitionersResource will retrieve practitioner(s) from the insolvency resource
-	GetPractitionersResource(practitionerIDs []string, transactionID string) ([]models.PractitionerResourceDao, error)
+	GetPractitionersResource(practitionerIDs []string) ([]models.PractitionerResourceDao, error)
 
 	// DeletePractitioner will delete a practitioner from the Insolvency resource
 	DeletePractitioner(practitionerID, transactionID string) (int, error)

--- a/handlers/practitioner_resource.go
+++ b/handlers/practitioner_resource.go
@@ -110,7 +110,7 @@ func HandleCreatePractitionersResource(svc dao.Service, helperService utils.Help
 		// Check if practitioner is already assigned to this case
 		extractedPractitionerIds := utils.ConvertMapToStringArray(practitionersMapResource)
 
-		practitionerResourceDaos, err := svc.GetPractitionersResource(extractedPractitionerIds, transactionID)
+		practitionerResourceDaos, err := svc.GetPractitionersResource(extractedPractitionerIds)
 		for _, practitionerResourceDao := range practitionerResourceDaos {
 			if err == nil && practitionerDao.Data.IPCode == practitionerResourceDao.Data.IPCode {
 				logErrorAndHttpResponse(w, req, http.StatusBadRequest, "error", []error{fmt.Errorf("there was a problem handling your request for transaction %s - practitioner with IP Code %s already is already assigned to this case", transactionID, practitionerResourceDao.Data.IPCode)})
@@ -203,7 +203,7 @@ func HandleGetPractitionerResource(svc dao.Service) http.Handler {
 		log.InfoR(req, fmt.Sprintf("start GET request for practitioner resource with transaction id: %s and practitioner id: %s", transactionID, practitionerID))
 
 		// Get practitioner from DB
-		practitionerResources, err := svc.GetPractitionersResource([]string{practitionerID}, transactionID)
+		practitionerResources, err := svc.GetPractitionersResource([]string{practitionerID})
 		if err != nil {
 			logErrorAndHttpResponse(w, req, http.StatusInternalServerError, "error", []error{fmt.Errorf("failed to get practitioner with id [%s]: [%s]", practitionerID, err),
 				fmt.Errorf("there was a problem handling your request")})
@@ -266,6 +266,7 @@ func HandleDeletePractitioner(svc dao.Service) http.Handler {
 func HandleAppointPractitioner(svc dao.Service, helperService utils.HelperService) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		var appointmentResponse models.AppointedPractitionerResource
+
 		// generate etag for request
 		etag, err := helperService.GenerateEtag()
 		if err != nil {
@@ -375,7 +376,7 @@ func HandleGetPractitionerAppointment(svc dao.Service) http.Handler {
 
 		log.InfoR(req, fmt.Sprintf("start GET request for appointments resource with transaction ID: [%s] and practitioner ID: [%s]", transactionID, practitionerID))
 
-		practitionerResourceDtos, err := svc.GetPractitionersResource([]string{practitionerID}, transactionID)
+		practitionerResourceDtos, err := svc.GetPractitionersResource([]string{practitionerID})
 		if err != nil {
 			logErrorAndHttpResponse(w, req, http.StatusInternalServerError, "error", []error{err})
 			return

--- a/handlers/practitioner_resource_test.go
+++ b/handlers/practitioner_resource_test.go
@@ -468,7 +468,7 @@ func TestUnitHandleCreatePractitionersResource(t *testing.T) {
 		mockService.EXPECT().GetInsolvencyPractitionersResource(gomock.Any()).Return(nil, nil, fmt.Errorf("there was a problem handling your request for transaction %s", transactionID)).Times(1)
 		// Expect GetInsolvencyPractitionersResource to return a valid insolvency case
 		mockService.EXPECT().GetInsolvencyPractitionersResource(gomock.Any()).Return(generateInsolvencyPractitionerAppointmentResources(), nil, nil).Times(2)
-		mockService.EXPECT().GetPractitionersResource(gomock.Any(), gomock.Any()).Return(practitionerResourceDaos, nil)
+		mockService.EXPECT().GetPractitionersResource(gomock.Any()).Return(practitionerResourceDaos, nil)
 		mockService.EXPECT().CreatePractitionerResource(gomock.Any(), gomock.Any()).Return(200, nil)
 		mockService.EXPECT().UpdateInsolvencyPractitioners(gomock.Any(), gomock.Any()).Return(200, nil)
 
@@ -505,7 +505,7 @@ func TestUnitHandleCreatePractitionersResource(t *testing.T) {
 		mockHelperService.EXPECT().HandleMandatoryFieldValidation(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 
 		mockService.EXPECT().GetInsolvencyPractitionersResource(gomock.Any()).Return(&dataDto, nil, nil).Times(2)
-		mockService.EXPECT().GetPractitionersResource(gomock.Any(), gomock.Any()).Return(practitionerResourceDaos, nil)
+		mockService.EXPECT().GetPractitionersResource(gomock.Any()).Return(practitionerResourceDaos, nil)
 		mockService.EXPECT().CreatePractitionerResource(gomock.Any(), gomock.Any()).Return(200, nil)
 		mockService.EXPECT().UpdateInsolvencyPractitioners(gomock.Any(), gomock.Any()).Return(404, fmt.Errorf("there was a problem handling your request for transaction %s", transactionID))
 
@@ -532,7 +532,7 @@ func TestUnitHandleCreatePractitionersResource(t *testing.T) {
 		mockHelperService.EXPECT().HandleMandatoryFieldValidation(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 
 		mockService.EXPECT().GetInsolvencyPractitionersResource(gomock.Any()).Return(nil, nil, fmt.Errorf("there was a problem handling your request for transaction %s already has 5 practitioners", transactionID)).Times(2)
-		mockService.EXPECT().GetPractitionersResource(gomock.Any(), gomock.Any()).Return(practitionerResourceDaos, nil)
+		mockService.EXPECT().GetPractitionersResource(gomock.Any()).Return(practitionerResourceDaos, nil)
 		mockService.EXPECT().CreatePractitionerResource(gomock.Any(), gomock.Any()).Return(200, nil)
 		mockService.EXPECT().UpdateInsolvencyPractitioners(gomock.Any(), gomock.Any()).Return(200, nil)
 
@@ -577,7 +577,7 @@ func TestUnitHandleCreatePractitionersResource(t *testing.T) {
 		mockHelperService.EXPECT().HandleMandatoryFieldValidation(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 
 		mockService.EXPECT().GetInsolvencyPractitionersResource(gomock.Any()).Return(&dataDto, nil, nil).Times(2)
-		mockService.EXPECT().GetPractitionersResource(gomock.Any(), gomock.Any()).Return(practitionerResourceDaos, nil)
+		mockService.EXPECT().GetPractitionersResource(gomock.Any()).Return(practitionerResourceDaos, nil)
 		mockService.EXPECT().CreatePractitionerResource(gomock.Any(), gomock.Any()).Return(200, nil)
 		mockService.EXPECT().UpdateInsolvencyPractitioners(gomock.Any(), gomock.Any()).Return(200, nil)
 
@@ -618,7 +618,7 @@ func TestUnitHandleCreatePractitionersResource(t *testing.T) {
 		mockHelperService.EXPECT().HandleMandatoryFieldValidation(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 
 		mockService.EXPECT().GetInsolvencyPractitionersResource(gomock.Any()).Return(insolvencyCase, nil, nil).Times(2)
-		mockService.EXPECT().GetPractitionersResource(gomock.Any(), gomock.Any()).Return(practitionerResourceDaos, nil)
+		mockService.EXPECT().GetPractitionersResource(gomock.Any()).Return(practitionerResourceDaos, nil)
 		mockService.EXPECT().CreatePractitionerResource(gomock.Any(), gomock.Any()).Return(200, nil)
 		mockService.EXPECT().UpdateInsolvencyPractitioners(gomock.Any(), gomock.Any()).Return(200, nil)
 
@@ -700,7 +700,7 @@ func TestUnitHandleGetPractitionerResources(t *testing.T) {
 		insolvencyCase.Data.CaseType = constants.CVL.String()
 
 		mockService.EXPECT().GetInsolvencyPractitionersResource(transactionID).Return(nil, nil, fmt.Errorf("there was a problem handling your request for transaction %s", transactionID)).Times(1)
-		mockService.EXPECT().GetPractitionersResource(gomock.Any(), gomock.Any()).Return(practitionerResourceDaos, nil).AnyTimes()
+		mockService.EXPECT().GetPractitionersResource(gomock.Any()).Return(practitionerResourceDaos, nil).AnyTimes()
 
 		res := serveGetPractitionersByIdssRequest(mockService, true)
 
@@ -716,7 +716,7 @@ func TestUnitHandleGetPractitionerResources(t *testing.T) {
 		insolvencyCase.Data.CaseType = constants.CVL.String()
 
 		mockService.EXPECT().GetInsolvencyPractitionersResource(transactionID).Return(nil, nil, nil).Times(1)
-		mockService.EXPECT().GetPractitionersResource(gomock.Any(), gomock.Any()).Return(practitionerResourceDaos, nil).AnyTimes()
+		mockService.EXPECT().GetPractitionersResource(gomock.Any()).Return(practitionerResourceDaos, nil).AnyTimes()
 
 		res := serveGetPractitionersByIdssRequest(mockService, true)
 
@@ -732,7 +732,7 @@ func TestUnitHandleGetPractitionerResources(t *testing.T) {
 		insolvencyCase.Data.CaseType = constants.CVL.String()
 
 		mockService.EXPECT().GetInsolvencyPractitionersResource(transactionID).Return(nil, nil, nil).Times(1)
-		mockService.EXPECT().GetPractitionersResource(gomock.Any(), gomock.Any()).Return(practitionerResourceDaos, nil).AnyTimes()
+		mockService.EXPECT().GetPractitionersResource(gomock.Any()).Return(practitionerResourceDaos, nil).AnyTimes()
 
 		res := serveGetPractitionersByIdssRequest(mockService, true)
 
@@ -764,7 +764,7 @@ func TestUnitHandleGetPractitionerResources(t *testing.T) {
 		insolvencyCase.Data.CaseType = constants.CVL.String()
 
 		mockService.EXPECT().GetInsolvencyPractitionersResource(transactionID).Return(&dataDto, nil, fmt.Errorf("there was a problem handling your request for transaction %s already has 5 practitioners", transactionID)).Times(1)
-		mockService.EXPECT().GetPractitionersResource(gomock.Any(), gomock.Any()).Return(practitionerResourceDaos, nil).AnyTimes()
+		mockService.EXPECT().GetPractitionersResource(gomock.Any()).Return(practitionerResourceDaos, nil).AnyTimes()
 
 		res := serveGetPractitionersByIdssRequest(mockService, true)
 
@@ -848,7 +848,7 @@ func TestUnitHandleGetPractitionerResource(t *testing.T) {
 
 		mockService := mock_dao.NewMockService(mockCtrl)
 		// Expect GetPractitionersResource to return an error
-		mockService.EXPECT().GetPractitionersResource(gomock.Any(), gomock.Any()).Return(practitionerResourceDaos, fmt.Errorf("error retrieving practitioner"))
+		mockService.EXPECT().GetPractitionersResource(gomock.Any()).Return(practitionerResourceDaos, fmt.Errorf("error retrieving practitioner"))
 
 		res := serveGetPractitionersByIdsRequest(mockService, true, true)
 
@@ -861,7 +861,7 @@ func TestUnitHandleGetPractitionerResource(t *testing.T) {
 
 		mockService := mock_dao.NewMockService(mockCtrl)
 		// Expect GetPractitionersResource to return an empty practitioner resource
-		mockService.EXPECT().GetPractitionersResource(gomock.Any(), gomock.Any()).Return(nil, nil)
+		mockService.EXPECT().GetPractitionersResource(gomock.Any()).Return(nil, nil)
 
 		res := serveGetPractitionersByIdsRequest(mockService, true, true)
 
@@ -874,7 +874,7 @@ func TestUnitHandleGetPractitionerResource(t *testing.T) {
 
 		mockService := mock_dao.NewMockService(mockCtrl)
 		// Expect GetPractitionersResource to successfully return a practitioner resource
-		mockService.EXPECT().GetPractitionersResource(gomock.Any(), gomock.Any()).Return(practitionerResourceDaos, nil)
+		mockService.EXPECT().GetPractitionersResource(gomock.Any()).Return(practitionerResourceDaos, nil)
 
 		res := serveGetPractitionersByIdsRequest(mockService, true, true)
 
@@ -1142,7 +1142,7 @@ func TestUnitHandleAppointPractitioner(t *testing.T) {
 		mockHelperService.EXPECT().HandleBodyDecodedValidation(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 		mockHelperService.EXPECT().HandleMandatoryFieldValidation(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 
-		mockService.EXPECT().GetPractitionersResource(gomock.Any(), gomock.Any()).Return(nil, fmt.Errorf("error"))
+		mockService.EXPECT().GetPractitionersResource(gomock.Any()).Return(nil, fmt.Errorf("error"))
 		mockService.EXPECT().CreateAppointmentResource(gomock.Any()).Return(200, nil)
 		mockService.EXPECT().UpdatePractitionerAppointment(gomock.Any(), gomock.Any(), gomock.Any()).Return(200, nil)
 
@@ -1217,7 +1217,7 @@ func TestUnitHandleAppointPractitioner(t *testing.T) {
 		mockHelperService.EXPECT().HandleBodyDecodedValidation(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 		mockHelperService.EXPECT().HandleMandatoryFieldValidation(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 
-		mockService.EXPECT().GetPractitionersResource(gomock.Any(), gomock.Any()).Return(practitionerResourceDaos, nil)
+		mockService.EXPECT().GetPractitionersResource(gomock.Any()).Return(practitionerResourceDaos, nil)
 		mockService.EXPECT().GetInsolvencyPractitionersResource(transactionID).Return(&insolvencyDao, practitionerResourceDaos, nil)
 		mockService.EXPECT().CreateAppointmentResource(gomock.Any()).Return(200, nil)
 		mockService.EXPECT().UpdatePractitionerAppointment(gomock.Any(), gomock.Any(), gomock.Any()).Return(200, nil)
@@ -1251,7 +1251,7 @@ func TestUnitHandleAppointPractitioner(t *testing.T) {
 		mockHelperService.EXPECT().HandleBodyDecodedValidation(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 		mockHelperService.EXPECT().HandleMandatoryFieldValidation(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 
-		mockService.EXPECT().GetPractitionersResource(gomock.Any(), gomock.Any()).Return(practitionerResourceDaos, fmt.Errorf("error"))
+		mockService.EXPECT().GetPractitionersResource(gomock.Any()).Return(practitionerResourceDaos, fmt.Errorf("error"))
 		mockService.EXPECT().GetInsolvencyPractitionersResource(transactionID).Return(&models.InsolvencyResourceDao{}, practitionerResourceDaos, fmt.Errorf("error"))
 		mockService.EXPECT().CreateAppointmentResource(gomock.Any()).Return(200, nil)
 		mockService.EXPECT().UpdatePractitionerAppointment(gomock.Any(), gomock.Any(), gomock.Any()).Return(200, nil)
@@ -1302,7 +1302,7 @@ func TestUnitHandleAppointPractitioner(t *testing.T) {
 		mockHelperService.EXPECT().HandleBodyDecodedValidation(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 		mockHelperService.EXPECT().HandleMandatoryFieldValidation(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 
-		mockService.EXPECT().GetPractitionersResource(gomock.Any(), gomock.Any()).Return(practitionerResourceDaos, nil).AnyTimes()
+		mockService.EXPECT().GetPractitionersResource(gomock.Any()).Return(practitionerResourceDaos, nil).AnyTimes()
 		mockService.EXPECT().GetInsolvencyPractitionersResource(transactionID).Return(&insolvencyDao, practitionerResourceDaos, nil)
 		mockService.EXPECT().CreateAppointmentResource(gomock.Any()).Return(200, nil)
 		mockService.EXPECT().UpdatePractitionerAppointment(gomock.Any(), gomock.Any(), gomock.Any()).Return(200, nil)
@@ -1339,7 +1339,7 @@ func TestUnitHandleAppointPractitioner(t *testing.T) {
 		mockHelperService.EXPECT().HandleMandatoryFieldValidation(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true).AnyTimes()
 
 		mockService.EXPECT().GetInsolvencyPractitionersResource(gomock.Any()).Return(&insolvencyDao, nil, nil)
-		mockService.EXPECT().GetPractitionersResource(gomock.Any(), gomock.Any()).Return(nil, nil)
+		mockService.EXPECT().GetPractitionersResource(gomock.Any()).Return(nil, nil)
 		mockService.EXPECT().GetPractitionerAppointment(gomock.Any(), gomock.Any()).Return(&models.AppointmentResourceDao{}, fmt.Errorf("error occured"))
 		mockService.EXPECT().CreateAppointmentResource(gomock.Any()).Return(200, nil)
 		mockService.EXPECT().UpdatePractitionerAppointment(gomock.Any(), gomock.Any(), gomock.Any()).Return(200, nil)
@@ -1390,7 +1390,7 @@ func TestUnitHandleAppointPractitioner(t *testing.T) {
 
 		mockService.EXPECT().GetPractitionerAppointment(gomock.Any(), gomock.Any()).Return(&models.AppointmentResourceDao{}, nil)
 		mockService.EXPECT().GetInsolvencyPractitionersResource(gomock.Any()).Return(&insolvencyDao, practitionerResourceDaos, nil)
-		mockService.EXPECT().GetPractitionersResource(gomock.Any(), gomock.Any()).Return([]models.PractitionerResourceDao{}, nil)
+		mockService.EXPECT().GetPractitionersResource(gomock.Any()).Return([]models.PractitionerResourceDao{}, nil)
 		mockService.EXPECT().CreateAppointmentResource(gomock.Any()).Return(200, nil)
 		mockService.EXPECT().UpdatePractitionerAppointment(gomock.Any(), gomock.Any(), gomock.Any()).Return(200, nil)
 
@@ -1482,7 +1482,7 @@ func TestUnitHandleGetPractitionerAppointment(t *testing.T) {
 		defer mockCtrl.Finish()
 
 		mockService := mock_dao.NewMockService(mockCtrl)
-		mockService.EXPECT().GetPractitionersResource(gomock.Any(), gomock.Any()).Return(practitionerResourceDaos, fmt.Errorf("error"))
+		mockService.EXPECT().GetPractitionersResource(gomock.Any()).Return(practitionerResourceDaos, fmt.Errorf("error"))
 
 		body, _ := json.Marshal(models.PractitionerAppointment{
 			AppointedOn: "2012-02-23",
@@ -1498,7 +1498,7 @@ func TestUnitHandleGetPractitionerAppointment(t *testing.T) {
 		defer mockCtrl.Finish()
 
 		mockService := mock_dao.NewMockService(mockCtrl)
-		mockService.EXPECT().GetPractitionersResource(gomock.Any(), gomock.Any()).Return(nil, nil)
+		mockService.EXPECT().GetPractitionersResource(gomock.Any()).Return(nil, nil)
 
 		body, _ := json.Marshal(models.PractitionerAppointment{
 			AppointedOn: "2012-02-23",
@@ -1516,7 +1516,7 @@ func TestUnitHandleGetPractitionerAppointment(t *testing.T) {
 		mockService := mock_dao.NewMockService(mockCtrl)
 
 		practitionerResourceDaos[0].Data.Appointment = nil
-		mockService.EXPECT().GetPractitionersResource(gomock.Any(), gomock.Any()).Return(practitionerResourceDaos, nil)
+		mockService.EXPECT().GetPractitionersResource(gomock.Any()).Return(practitionerResourceDaos, nil)
 
 		body, _ := json.Marshal(models.PractitionerAppointment{
 			AppointedOn: "2012-02-23",
@@ -1543,7 +1543,7 @@ func TestUnitHandleGetPractitionerAppointment(t *testing.T) {
 
 		practitionerResourceDaos[0].Data.Appointment = &appointmentResourceDao
 
-		mockService.EXPECT().GetPractitionersResource(gomock.Any(), gomock.Any()).Return(practitionerResourceDaos, nil)
+		mockService.EXPECT().GetPractitionersResource(gomock.Any()).Return(practitionerResourceDaos, nil)
 
 		res := serveHandleGetPractitionerAppointment(body, mockService, true, true)
 

--- a/mocks/service_mock.go
+++ b/mocks/service_mock.go
@@ -114,16 +114,16 @@ func (mr *MockServiceMockRecorder) UpdateInsolvencyPractitioners(practitionersRe
 }
 
 // GetPractitionersResource mocks base method
-func (m *MockService) GetPractitionersResource(practitionerIDs []string, transactionID string) ([]models.PractitionerResourceDao, error)  {
-	ret := m.ctrl.Call(m, "GetPractitionersResource", practitionerIDs, transactionID)
+func (m *MockService) GetPractitionersResource(practitionerIDs []string) ([]models.PractitionerResourceDao, error)  {
+	ret := m.ctrl.Call(m, "GetPractitionersResource", practitionerIDs)
 	ret0, _ := ret[0].([]models.PractitionerResourceDao)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetPractitionersResource indicates an expected call of GetPractitionersResource
-func (mr *MockServiceMockRecorder) GetPractitionersResource(practitionerIDs, transactionID interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPractitionersResource", reflect.TypeOf((*MockService)(nil).GetPractitionersResource), practitionerIDs, transactionID)
+func (mr *MockServiceMockRecorder) GetPractitionersResource(practitionerIDs interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPractitionersResource", reflect.TypeOf((*MockService)(nil).GetPractitionersResource), practitionerIDs)
 }
 
 // DeletePractitioner mocks base method

--- a/models/data_entities.go
+++ b/models/data_entities.go
@@ -2,7 +2,7 @@ package models
 
 import "go.mongodb.org/mongo-driver/bson/primitive"
 
-// InsolvencyResourceDao contains the insolvency resource in Mongo
+// InsolvencyResourceDao contains insolvency resource in Mongo
 type InsolvencyResourceDao struct {
 	ID            primitive.ObjectID `bson:"_id"`
 	TransactionID string             `bson:"transaction_id"`


### PR DESCRIPTION
add logics to delete practitioners

update mongo driver tests

This PR update, fix unit tests and did manual tests for the following endpoints:

1. "/{transaction_id}/insolvency/practitioners/{practitioner_id}", HandleDeletePractitioner --delete practitioner(s)
2. "/{transaction_id}/insolvency/practitioners/{practitioner_id}/appointment", HandleDeletePractitionerAppointment --delete practitioners appointment.
3. Insolvency collection is also cleansed of deleted practitioner as deleted appointment(s) cleansed from practitioner collection.


