### PR TITLE
remove SOC includes SOAD attachment validation check

### DIFF
--- a/handlers/soa_resource.go
+++ b/handlers/soa_resource.go
@@ -64,9 +64,9 @@ func HandleCreateStatementOfAffairs(svc dao.Service, helperService utils.HelperS
 		}
 
 		// Validate the supplied attachment is a valid type
-		if attachment.Type != "statement-of-affairs-director" && attachment.Type != "statement-of-affairs-liquidator" {
+		if attachment.Type != "statement-of-affairs-director" && attachment.Type != "statement-of-affairs-liquidator"  && attachment.Type != "statement-of-concurrence" {
 			err := fmt.Errorf("attachment id [%s] is an invalid type for this request: %v", statementDao.Attachments[0], attachment.Type)
-			responseMessage := "attachment is not a statement-of-affairs-director or statement-of-affairs-liquidator"
+			responseMessage := "attachment is not a statement-of-affairs-director, statement-of-affairs-liquidator or a statement-of-concurrence"
 
 			helperService.HandleAttachmentTypeValidation(w, req, responseMessage, err)
 			return

--- a/handlers/soa_resource.go
+++ b/handlers/soa_resource.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/companieshouse/chs.go/log"
+	"github.com/companieshouse/insolvency-api/constants"
 	"github.com/companieshouse/insolvency-api/dao"
 	"github.com/companieshouse/insolvency-api/models"
 	"github.com/companieshouse/insolvency-api/service"
@@ -64,9 +65,9 @@ func HandleCreateStatementOfAffairs(svc dao.Service, helperService utils.HelperS
 		}
 
 		// Validate the supplied attachment is a valid type
-		if attachment.Type != "statement-of-affairs-director" && attachment.Type != "statement-of-affairs-liquidator"  && attachment.Type != "statement-of-concurrence" {
+		if attachment.Type != constants.StatementOfAffairsDirector.String() && attachment.Type != constants.StatementOfAffairsLiquidator.String() && attachment.Type != constants.StatementOfConcurrence.String() {
 			err := fmt.Errorf("attachment id [%s] is an invalid type for this request: %v", statementDao.Attachments[0], attachment.Type)
-			responseMessage := "attachment is not a statement-of-affairs-director, statement-of-affairs-liquidator or a statement-of-concurrence"
+			responseMessage := ("attachment is not a " + constants.StatementOfAffairsDirector.String() + ", " + constants.StatementOfAffairsLiquidator.String() + " or a " + constants.StatementOfConcurrence.String())
 
 			helperService.HandleAttachmentTypeValidation(w, req, responseMessage, err)
 			return

--- a/handlers/soa_resource_test.go
+++ b/handlers/soa_resource_test.go
@@ -278,7 +278,7 @@ func TestUnitHandleCreateStatementOfAffairs(t *testing.T) {
 		res := serveHandleCreateStatementOfAffairs(body, mockService, helperService, true, rec)
 
 		So(res.Code, ShouldEqual, http.StatusBadRequest)
-		So(res.Body.String(), ShouldContainSubstring, "attachment is not a statement-of-affairs-director or statement-of-affairs-liquidator")
+		So(res.Body.String(), ShouldContainSubstring, "attachment is not a statement-of-affairs-director, statement-of-affairs-liquidator or a statement-of-concurrence")
 	})
 
 	Convey("Generic error when adding statement of affairs resource to mongo", t, func() {

--- a/handlers/soa_resource_test.go
+++ b/handlers/soa_resource_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/companieshouse/chs.go/log"
+	"github.com/companieshouse/insolvency-api/constants"
 	"github.com/companieshouse/insolvency-api/dao"
 	mock_dao "github.com/companieshouse/insolvency-api/mocks"
 	"github.com/companieshouse/insolvency-api/models"
@@ -256,7 +257,7 @@ func TestUnitHandleCreateStatementOfAffairs(t *testing.T) {
 		So(res.Body.String(), ShouldContainSubstring, "please supply only one attachment")
 	})
 
-	Convey("Attachment is not of type statement-of-affairs-director or liquidator", t, func() {
+	Convey("Attachment is not of type statement-of-affairs-director, liquidator or concurrence", t, func() {
 		mockService, _, rec := mock_dao.CreateTestObjects(t)
 		httpmock.Activate()
 
@@ -278,7 +279,7 @@ func TestUnitHandleCreateStatementOfAffairs(t *testing.T) {
 		res := serveHandleCreateStatementOfAffairs(body, mockService, helperService, true, rec)
 
 		So(res.Code, ShouldEqual, http.StatusBadRequest)
-		So(res.Body.String(), ShouldContainSubstring, "attachment is not a statement-of-affairs-director, statement-of-affairs-liquidator or a statement-of-concurrence")
+		So(res.Body.String(), ShouldContainSubstring, "attachment is not a " + constants.StatementOfAffairsDirector.String() + ", " + constants.StatementOfAffairsLiquidator.String() + " or a " + constants.StatementOfConcurrence.String())
 	})
 
 	Convey("Generic error when adding statement of affairs resource to mongo", t, func() {

--- a/service/insolvency_service.go
+++ b/service/insolvency_service.go
@@ -68,18 +68,6 @@ func ValidateInsolvencyDetails(insolvencyResource models.InsolvencyResourceDao) 
 		attachmentTypes[attachment.Type] = struct{}{}
 	}
 
-	// Check if attachment type is statement-of-concurrence, if true then statement-of-affairs-director attachment must be present
-	_, hasStatementOfConcurrence := attachmentTypes["statement-of-concurrence"]
-
-	if hasStatementOfConcurrence {
-		_, hasStatementOfAffairsDirector := attachmentTypes["statement-of-affairs-director"]
-		if !hasStatementOfAffairsDirector {
-			validationError := fmt.Sprintf("error - attachment statement-of-concurrence must be accompanied by statement-of-affairs-director attachment for insolvency case with transaction id [%s]", insolvencyResource.TransactionID)
-			log.Info(validationError)
-			validationErrors = addValidationError(validationErrors, validationError, "statement of concurrence attachment type")
-		}
-	}
-
 	// Check if attachment type is statement-of-affairs-liquidator, if true then no practitioners must be appointed, but at least one should be present
 	_, hasStateOfAffairsLiquidator := attachmentTypes["statement-of-affairs-liquidator"]
 

--- a/service/insolvency_service.go
+++ b/service/insolvency_service.go
@@ -110,7 +110,7 @@ func ValidateInsolvencyDetails(insolvencyResource models.InsolvencyResourceDao) 
 		validationErrors = addValidationError(validationErrors, validationError, "attachment ids do not match")
 	}
 
-	// Check if "statement-of-affairs-director" or "statement-of-affairs-liquidator" has been filed, if so, then a statement date must be present
+	// Check if SOA-D and/or SOC, or SOA-L has been filed, if so, then a statement date must be present
 	_, hasStatementOfConcurrence := attachmentTypes[constants.StatementOfConcurrence.String()]
 	_, hasStatementOfAffairsDirector := attachmentTypes[constants.StatementOfAffairsDirector.String()]
 	if (hasStatementOfAffairsDirector || hasStateOfAffairsLiquidator || hasStatementOfConcurrence) && (insolvencyResource.Data.StatementOfAffairs == nil || insolvencyResource.Data.StatementOfAffairs.StatementDate == "") {

--- a/service/insolvency_service.go
+++ b/service/insolvency_service.go
@@ -69,7 +69,7 @@ func ValidateInsolvencyDetails(insolvencyResource models.InsolvencyResourceDao) 
 	}
 
 	// Check if attachment type is statement-of-affairs-liquidator, if true then no practitioners must be appointed, but at least one should be present
-	_, hasStateOfAffairsLiquidator := attachmentTypes["statement-of-affairs-liquidator"]
+	_, hasStateOfAffairsLiquidator := attachmentTypes[constants.StatementOfAffairsLiquidator.String()]
 
 	if hasStateOfAffairsLiquidator && hasAppointedPractitioner {
 		validationError := fmt.Sprintf("error - no appointed practitioners can be assigned to the case when attachment type statement-of-affairs-liquidator is included with transaction id [%s]", insolvencyResource.TransactionID)
@@ -111,16 +111,17 @@ func ValidateInsolvencyDetails(insolvencyResource models.InsolvencyResourceDao) 
 	}
 
 	// Check if "statement-of-affairs-director" or "statement-of-affairs-liquidator" has been filed, if so, then a statement date must be present
+	_, hasStatementOfConcurrence := attachmentTypes[constants.StatementOfConcurrence.String()]
 	_, hasStatementOfAffairsDirector := attachmentTypes[constants.StatementOfAffairsDirector.String()]
-	if (hasStatementOfAffairsDirector || hasStateOfAffairsLiquidator) && (insolvencyResource.Data.StatementOfAffairs == nil || insolvencyResource.Data.StatementOfAffairs.StatementDate == "") {
-		validationError := fmt.Sprintf("error - a date of statement of affairs must be present as there is an attachment with type [%s] or [%s] for insolvency case with transaction id [%s]", constants.StatementOfAffairsDirector.String(), constants.StatementOfAffairsLiquidator.String(), insolvencyResource.TransactionID)
+	if (hasStatementOfAffairsDirector || hasStateOfAffairsLiquidator || hasStatementOfConcurrence) && (insolvencyResource.Data.StatementOfAffairs == nil || insolvencyResource.Data.StatementOfAffairs.StatementDate == "") {
+		validationError := fmt.Sprintf("error - a date of statement of affairs must be present as there is an attachment with a type of [%s], [%s], or a [%s] for insolvency case with transaction id [%s]", constants.StatementOfAffairsDirector.String(), constants.StatementOfConcurrence.String(), constants.StatementOfAffairsLiquidator.String(), insolvencyResource.TransactionID)
 		log.Info(validationError)
 		validationErrors = addValidationError(validationErrors, validationError, "statement-of-affairs")
 	}
 
-	// Check if SOA resource exists or statement date is not empty in DB, if not, then an SOA-D or SOA-L attachment must be filed
-	if insolvencyResource.Data.StatementOfAffairs != nil && insolvencyResource.Data.StatementOfAffairs.StatementDate != "" && !(hasStatementOfAffairsDirector || hasStateOfAffairsLiquidator) {
-		validationError := fmt.Sprintf("error - an attachment of type [%s] or [%s] must be present as there is a date of statement of affairs present for insolvency case with transaction id [%s]", constants.StatementOfAffairsDirector.String(), constants.StatementOfAffairsLiquidator.String(), insolvencyResource.TransactionID)
+	// Check if SOA resource exists or statement date is not empty in DB, if not, then an SOA-D and/or SOC, or SOA-L attachment must be filed
+	if insolvencyResource.Data.StatementOfAffairs != nil && insolvencyResource.Data.StatementOfAffairs.StatementDate != "" && !(hasStatementOfAffairsDirector || hasStateOfAffairsLiquidator || hasStatementOfConcurrence) {
+		validationError := fmt.Sprintf("error - an attachment of type [%s], [%s], or a [%s] must be present as there is a date of statement of affairs present for insolvency case with transaction id [%s]", constants.StatementOfAffairsDirector.String(), constants.StatementOfConcurrence.String(), constants.StatementOfAffairsLiquidator.String(), insolvencyResource.TransactionID)
 		log.Info(validationError)
 		validationErrors = addValidationError(validationErrors, validationError, "statement-of-affairs")
 	}

--- a/service/insolvency_service_test.go
+++ b/service/insolvency_service_test.go
@@ -272,22 +272,6 @@ func TestUnitValidateInsolvencyDetails(t *testing.T) {
 		So(validationErrors, ShouldHaveLength, 0)
 	})
 
-	Convey("error - attachment type is statement-of-concurrence and attachment type statement-of-affairs-director is not present", t, func() {
-		insolvencyCase := createInsolvencyResource()
-		// Set attachment type to "statement-of-concurrence"
-		insolvencyCase.Data.Attachments = append(insolvencyCase.Data.Attachments, models.AttachmentResourceDao{Type: "statement-of-concurrence"})
-		// Remove SOA director
-		insolvencyCase.Data.Attachments[1].Type = "type"
-		// Remove SOA
-		insolvencyCase.Data.StatementOfAffairs = nil
-
-		validationErrors := ValidateInsolvencyDetails(insolvencyCase)
-
-		So(validationErrors, ShouldHaveLength, 1)
-		So((*validationErrors)[0].Error, ShouldContainSubstring, fmt.Sprintf("error - attachment statement-of-concurrence must be accompanied by statement-of-affairs-director attachment for insolvency case with transaction id [%s]", insolvencyCase.TransactionID))
-		So((*validationErrors)[0].Location, ShouldContainSubstring, "statement of concurrence attachment type")
-	})
-
 	Convey("successful validation of statement-of-concurrence attachment - attachment type is statement-of-concurrence and statement-of-affairs-director are present", t, func() {
 		insolvencyCase := createInsolvencyResource()
 		insolvencyCase.Data.Resolution = nil

--- a/service/insolvency_service_test.go
+++ b/service/insolvency_service_test.go
@@ -443,7 +443,6 @@ func TestUnitValidateInsolvencyDetails(t *testing.T) {
 		So(validationErrors, ShouldHaveLength, 0)
 	})
 
-
 	// Loop through SOA attachment types to repeat test to convey the following:
 	// error - <attachment type> filed but no statement date/resource exists in DB
 	attachmentTypes := []string{"statement-of-affairs-director","statement-of-affairs-liquidator","statement-of-concurrence"}

--- a/service/insolvency_service_test.go
+++ b/service/insolvency_service_test.go
@@ -445,7 +445,7 @@ func TestUnitValidateInsolvencyDetails(t *testing.T) {
 
 	// Loop through SOA attachment types to repeat test to convey the following:
 	// error - <attachment type> filed but no statement date/resource exists in DB
-	attachmentTypes := []string{"statement-of-affairs-director","statement-of-affairs-liquidator","statement-of-concurrence"}
+	attachmentTypes := []string{constants.StatementOfAffairsDirector.String(), constants.StatementOfAffairsLiquidator.String(), constants.StatementOfConcurrence.String()}
 	contextList := []string{"date", "resource"}
 	for _, attachment := range attachmentTypes {
 		for _, contextItem := range contextList {

--- a/service/insolvency_service_test.go
+++ b/service/insolvency_service_test.go
@@ -544,6 +544,46 @@ func TestUnitValidateInsolvencyDetails(t *testing.T) {
 		So((*validationErrors)[0].Location, ShouldContainSubstring, "statement-of-affairs")
 	})
 
+    Convey("error - attachment type is statement-of-concurrence and practitioner object empty", t, func() {
+        insolvencyCase := createInsolvencyResource()
+
+        // Remove the Practitioners
+        insolvencyCase.Data.Practitioners = nil
+
+        // Replace statement-of-affairs-director attachment type to statement-of-concurrence for the 2nd attachment
+        insolvencyCase.Data.Attachments[0].Type = "type"
+        insolvencyCase.Data.Attachments[1].Type = "statement-of-concurrence"
+        insolvencyCase.Data.Attachments[2].Type = "type2"
+
+        // Remove the resolution/statement of affairs/progress report details
+        insolvencyCase.Data.Resolution = nil
+        insolvencyCase.Data.StatementOfAffairs = nil
+        insolvencyCase.Data.ProgressReport = nil
+
+        validationErrors := ValidateInsolvencyDetails(insolvencyCase)
+        So(validationErrors, ShouldHaveLength, 2)
+        So((*validationErrors)[0].Error, ShouldContainSubstring, fmt.Sprintf("error - attachment type requires that at least one practitioner must be present for insolvency case with transaction id [%s]", insolvencyCase.TransactionID))
+        So((*validationErrors)[1].Error, ShouldContainSubstring, "error - if no practitioners are present then an attachment of the type resolution must be present")
+
+    })
+
+    Convey("successful validation of statement-of-concurrence - attachment type is statement-of-concurrence and at least one practitioner present", t, func() {
+        insolvencyCase := createInsolvencyResource()
+
+        // Replace statement-of-affairs-director attachment type to statement-of-concurrence for the 2nd attachment
+        insolvencyCase.Data.Attachments[0].Type = "type"
+        insolvencyCase.Data.Attachments[1].Type = "statement-of-concurrence"
+        insolvencyCase.Data.Attachments[2].Type = "type2"
+
+        // Remove the resolution/statement of affairs/progress report details
+        insolvencyCase.Data.Resolution = nil
+        insolvencyCase.Data.StatementOfAffairs = nil
+        insolvencyCase.Data.ProgressReport = nil
+
+        validationErrors := ValidateInsolvencyDetails(insolvencyCase)
+        So(validationErrors, ShouldHaveLength, 0)
+    })
+    
 	Convey("error - practitioner appointment is before date of resolution", t, func() {
 		// Add resolution to insolvency case
 		insolvencyCase := createInsolvencyResource()

--- a/service/insolvency_service_test.go
+++ b/service/insolvency_service_test.go
@@ -442,131 +442,6 @@ func TestUnitValidateInsolvencyDetails(t *testing.T) {
 		validationErrors := ValidateInsolvencyDetails(insolvencyCase)
 		So(validationErrors, ShouldHaveLength, 0)
 	})
-
-	Convey("error - statement-of-affairs-director filed but no statement date exists in DB", t, func() {
-
-		// Create insolvency case and remove SOA date
-		insolvencyCase := createInsolvencyResource()
-		insolvencyCase.Data.StatementOfAffairs = &models.StatementOfAffairsResourceDao{
-			StatementDate: "",
-		}
-
-		validationErrors := ValidateInsolvencyDetails(insolvencyCase)
-
-		So(validationErrors, ShouldHaveLength, 1)
-		So((*validationErrors)[0].Error, ShouldContainSubstring, fmt.Sprintf("error - a date of statement of affairs must be present as there is an attachment with type [%s] or [%s] for insolvency case with transaction id [%s]", constants.StatementOfAffairsDirector.String(), constants.StatementOfAffairsLiquidator.String(), insolvencyCase.TransactionID))
-		So((*validationErrors)[0].Location, ShouldContainSubstring, "statement-of-affairs")
-	})
-
-	Convey("error - statement-of-affairs-liquidator filed but no statement resource exists in DB", t, func() {
-
-		// Create insolvency case
-		insolvencyCase := createInsolvencyResource()
-
-		// Remove practitioner to prevent triggering another error
-		insolvencyCase.Data.Practitioners = make([]models.PractitionerResourceDao, 0)
-
-		// Change attachment type to SOA-L
-		insolvencyCase.Data.Attachments[1].Type = "statement-of-affairs-liquidator"
-
-		// Make statement date an empty string
-		insolvencyCase.Data.StatementOfAffairs = &models.StatementOfAffairsResourceDao{
-			StatementDate: "",
-		}
-
-		validationErrors := ValidateInsolvencyDetails(insolvencyCase)
-
-		So(validationErrors, ShouldHaveLength, 1)
-		So((*validationErrors)[0].Error, ShouldContainSubstring, fmt.Sprintf("error - a date of statement of affairs must be present as there is an attachment with type [%s] or [%s] for insolvency case with transaction id [%s]", constants.StatementOfAffairsDirector.String(), constants.StatementOfAffairsLiquidator.String(), insolvencyCase.TransactionID))
-		So((*validationErrors)[0].Location, ShouldContainSubstring, "statement-of-affairs")
-	})
-
-	Convey("error - statement-of-affairs-director filed but no statement resource exists in DB", t, func() {
-
-		// Create insolvency case and remove SOA date
-		insolvencyCase := createInsolvencyResource()
-		insolvencyCase.Data.StatementOfAffairs = nil
-
-		validationErrors := ValidateInsolvencyDetails(insolvencyCase)
-
-		So(validationErrors, ShouldHaveLength, 1)
-		So((*validationErrors)[0].Error, ShouldContainSubstring, fmt.Sprintf("error - a date of statement of affairs must be present as there is an attachment with type [%s] or [%s] for insolvency case with transaction id [%s]", constants.StatementOfAffairsDirector.String(), constants.StatementOfAffairsLiquidator.String(), insolvencyCase.TransactionID))
-		So((*validationErrors)[0].Location, ShouldContainSubstring, "statement-of-affairs")
-	})
-
-	Convey("error - statement-of-affairs-liquidator filed but no statement resource exists in DB", t, func() {
-
-		// Create insolvency case
-		insolvencyCase := createInsolvencyResource()
-
-		// Remove practitioner to prevent triggering another error
-		insolvencyCase.Data.Practitioners = make([]models.PractitionerResourceDao, 0)
-
-		// Change attachment type to SOA-L
-		insolvencyCase.Data.Attachments[1].Type = "statement-of-affairs-liquidator"
-
-		// Remove statement resource
-		insolvencyCase.Data.StatementOfAffairs = nil
-
-		validationErrors := ValidateInsolvencyDetails(insolvencyCase)
-
-		So(validationErrors, ShouldHaveLength, 1)
-		So((*validationErrors)[0].Error, ShouldContainSubstring, fmt.Sprintf("error - a date of statement of affairs must be present as there is an attachment with type [%s] or [%s] for insolvency case with transaction id [%s]", constants.StatementOfAffairsDirector.String(), constants.StatementOfAffairsLiquidator.String(), insolvencyCase.TransactionID))
-		So((*validationErrors)[0].Location, ShouldContainSubstring, "statement-of-affairs")
-	})
-
-	Convey("error - statement resource exists in DB but no statement-of-affairs attachment filed", t, func() {
-
-		// Create insolvency case and remove SOA date
-		insolvencyCase := createInsolvencyResource()
-		insolvencyCase.Data.Attachments[1].Type = "random"
-
-		validationErrors := ValidateInsolvencyDetails(insolvencyCase)
-
-		So(validationErrors, ShouldHaveLength, 1)
-		So((*validationErrors)[0].Error, ShouldContainSubstring, fmt.Sprintf("error - an attachment of type [%s] or [%s] must be present as there is a date of statement of affairs present for insolvency case with transaction id [%s]", constants.StatementOfAffairsDirector.String(), constants.StatementOfAffairsLiquidator.String(), insolvencyCase.TransactionID))
-		So((*validationErrors)[0].Location, ShouldContainSubstring, "statement-of-affairs")
-	})
-
-    Convey("error - attachment type is statement-of-concurrence and practitioner object empty", t, func() {
-        insolvencyCase := createInsolvencyResource()
-
-        // Remove the Practitioners
-        insolvencyCase.Data.Practitioners = nil
-
-        // Replace statement-of-affairs-director attachment type to statement-of-concurrence for the 2nd attachment
-        insolvencyCase.Data.Attachments[0].Type = "type"
-        insolvencyCase.Data.Attachments[1].Type = "statement-of-concurrence"
-        insolvencyCase.Data.Attachments[2].Type = "type2"
-
-        // Remove the resolution/statement of affairs/progress report details
-        insolvencyCase.Data.Resolution = nil
-        insolvencyCase.Data.StatementOfAffairs = nil
-        insolvencyCase.Data.ProgressReport = nil
-
-        validationErrors := ValidateInsolvencyDetails(insolvencyCase)
-        So(validationErrors, ShouldHaveLength, 2)
-        So((*validationErrors)[0].Error, ShouldContainSubstring, fmt.Sprintf("error - attachment type requires that at least one practitioner must be present for insolvency case with transaction id [%s]", insolvencyCase.TransactionID))
-        So((*validationErrors)[1].Error, ShouldContainSubstring, "error - if no practitioners are present then an attachment of the type resolution must be present")
-
-    })
-
-    Convey("successful validation of statement-of-concurrence - attachment type is statement-of-concurrence and at least one practitioner present", t, func() {
-        insolvencyCase := createInsolvencyResource()
-
-        // Replace statement-of-affairs-director attachment type to statement-of-concurrence for the 2nd attachment
-        insolvencyCase.Data.Attachments[0].Type = "type"
-        insolvencyCase.Data.Attachments[1].Type = "statement-of-concurrence"
-        insolvencyCase.Data.Attachments[2].Type = "type2"
-
-        // Remove the resolution/statement of affairs/progress report details
-        insolvencyCase.Data.Resolution = nil
-        insolvencyCase.Data.StatementOfAffairs = nil
-        insolvencyCase.Data.ProgressReport = nil
-
-        validationErrors := ValidateInsolvencyDetails(insolvencyCase)
-        So(validationErrors, ShouldHaveLength, 0)
-    })
     
 	Convey("error - practitioner appointment is before date of resolution", t, func() {
 		// Add resolution to insolvency case
@@ -752,6 +627,93 @@ func TestUnitValidateInsolvencyDetails(t *testing.T) {
 		})
 	})
 
+}
+
+func TestUnitValidateStatementOfAffairs(t *testing.T) {
+	httpmock.Activate()
+	defer httpmock.DeactivateAndReset()
+
+	contextList := []string{"date","resource"}
+	attachmentTypes := []string{"statement-of-affairs-director","statement-of-affairs-liquidator","statement-of-concurrence"}
+	for _, contextItem := range contextList {
+		for _, attachment := range attachmentTypes {
+			conveyTitle := "error - " + attachment + " filed but no statement " + contextItem + " exists in DB"
+			Convey(conveyTitle, t, func() {
+				// Create insolvency case and remove SOA date
+				insolvencyCase := createInsolvencyResource()
+				if contextItem == "date" {
+					insolvencyCase.Data.StatementOfAffairs = &models.StatementOfAffairsResourceDao{
+						StatementDate: "",
+					}
+				}
+				if contextItem == "resource" {
+					insolvencyCase.Data.StatementOfAffairs = nil
+				}
+
+				// Change attachment type
+				insolvencyCase.Data.Attachments[1].Type = attachment
+
+				if attachment == constants.StatementOfAffairsLiquidator.String() {
+					// Remove practitioner to prevent triggering another error
+					insolvencyCase.Data.Practitioners = make([]models.PractitionerResourceDao, 0)
+				}
+
+				validationErrors := ValidateInsolvencyDetails(insolvencyCase)
+				So(validationErrors, ShouldHaveLength, 1)
+				So((*validationErrors)[0].Error, ShouldContainSubstring, fmt.Sprintf("error - a date of statement of affairs must be present as there is an attachment with a type of [%s], [%s], or a [%s] for insolvency case with transaction id [%s]", constants.StatementOfAffairsDirector.String(), constants.StatementOfConcurrence.String(), constants.StatementOfAffairsLiquidator.String(), insolvencyCase.TransactionID))
+				So((*validationErrors)[0].Location, ShouldContainSubstring, "statement-of-affairs")
+			})
+		}
+	}
+
+	Convey("error - statement resource exists in DB but no statement-of-affairs attachment filed", t, func() {
+
+		// Create insolvency case and remove SOA date
+		insolvencyCase := createInsolvencyResource()
+		insolvencyCase.Data.Attachments[1].Type = "random"
+
+		validationErrors := ValidateInsolvencyDetails(insolvencyCase)
+
+		So(validationErrors, ShouldHaveLength, 1)
+		So((*validationErrors)[0].Error, ShouldContainSubstring, fmt.Sprintf("error - an attachment of type [%s], [%s], or a [%s] must be present as there is a date of statement of affairs present for insolvency case with transaction id [%s]", constants.StatementOfAffairsDirector.String(), constants.StatementOfConcurrence.String(), constants.StatementOfAffairsLiquidator.String(), insolvencyCase.TransactionID))
+		So((*validationErrors)[0].Location, ShouldContainSubstring, "statement-of-affairs")
+	})
+
+	Convey("error - attachment type is statement-of-concurrence and practitioner object empty", t, func() {
+		insolvencyCase := createInsolvencyResource()
+		// Remove the Practitioners
+		insolvencyCase.Data.Practitioners = nil
+
+		// Replace statement-of-affairs-director attachment type to statement-of-concurrence for the 2nd attachment
+		insolvencyCase.Data.Attachments[0].Type = "type"
+		insolvencyCase.Data.Attachments[1].Type = "statement-of-concurrence"
+		insolvencyCase.Data.Attachments[2].Type = "type2"
+
+		// Remove the resolution and progress report details
+		insolvencyCase.Data.Resolution = nil
+		insolvencyCase.Data.ProgressReport = nil
+
+		validationErrors := ValidateInsolvencyDetails(insolvencyCase)
+		So(validationErrors, ShouldHaveLength, 2)
+		So((*validationErrors)[0].Error, ShouldContainSubstring, fmt.Sprintf("error - attachment type requires that at least one practitioner must be present for insolvency case with transaction id [%s]", insolvencyCase.TransactionID))
+		So((*validationErrors)[1].Error, ShouldContainSubstring, "error - if no practitioners are present then an attachment of the type resolution must be present")
+	})
+
+	Convey("successful validation of statement-of-concurrence - attachment type is statement-of-concurrence and at least one practitioner present", t, func() {
+		insolvencyCase := createInsolvencyResource()
+
+		// Replace statement-of-affairs-director attachment type to statement-of-concurrence for the 2nd attachment
+		insolvencyCase.Data.Attachments[0].Type = "type"
+		insolvencyCase.Data.Attachments[1].Type = "statement-of-concurrence"
+		insolvencyCase.Data.Attachments[2].Type = "type2"
+
+		// Remove the resolution and progress report details
+		insolvencyCase.Data.Resolution = nil
+		insolvencyCase.Data.ProgressReport = nil
+
+		validationErrors := ValidateInsolvencyDetails(insolvencyCase)
+		So(validationErrors, ShouldHaveLength, 0)
+	})
 }
 
 func TestUnitValidateAntivirus(t *testing.T) {


### PR DESCRIPTION
1. Removed the validation check to ensure a statement-of-affairs-director attachment is present with the filing of a statement-of-concurrence.
2. Added a unit test to ensure that when a statement-of-concurrence is filed separately then it still requires the presence of at least one practitioner.