### PR TITLE
Validate params used in API calls [IEP-449]

### DIFF
--- a/handlers/insolvency_resource_test.go
+++ b/handlers/insolvency_resource_test.go
@@ -127,6 +127,21 @@ func TestUnitHandleCreateInsolvencyResource(t *testing.T) {
 		So(res.Body.String(), ShouldContainSubstring, "company_number is a required field")
 	})
 
+	Convey("Incoming request has invalid company number", t, func() {
+		mockService, _, rec := mock_dao.CreateTestObjects(t)
+
+		body, _ := json.Marshal(&models.InsolvencyRequest{
+			CaseType:      constants.MVL.String(),
+			CompanyName:   companyName,
+			CompanyNumber: "companyNumberWithPercent%",
+		})
+
+		res := serveHandleCreateInsolvencyResource(body, mockService, true, helperService, rec)
+
+		So(res.Code, ShouldEqual, http.StatusBadRequest)
+		So(res.Body.String(), ShouldContainSubstring, "invalid request body: company_number can only contain alphanumeric characters")
+	})
+
 	Convey("Incoming request has company name missing", t, func() {
 		mockService, _, rec := mock_dao.CreateTestObjects(t)
 

--- a/handlers/register.go
+++ b/handlers/register.go
@@ -7,11 +7,18 @@ import (
 	"github.com/companieshouse/chs.go/authentication"
 	"github.com/companieshouse/chs.go/log"
 	"github.com/companieshouse/insolvency-api/config"
-	"github.com/companieshouse/insolvency-api/constants"
 	"github.com/companieshouse/insolvency-api/dao"
 	"github.com/companieshouse/insolvency-api/interceptors"
 	"github.com/companieshouse/insolvency-api/utils"
 	"github.com/gorilla/mux"
+)
+
+const (
+	digitsAndDashRegex     = "[0-9-]+"
+	insolvencyPath         = "/{transaction_id:" + digitsAndDashRegex + "}/insolvency"
+	uuidCharsRegex         = "[a-f0-9-]+"
+	attachmentsPath        = insolvencyPath + "/attachments"
+	specificAttachmentPath = attachmentsPath + "/{attachment_id:" + uuidCharsRegex + "}"
 )
 
 // Register defines the endpoints for the API
@@ -34,31 +41,31 @@ func Register(mainRouter *mux.Router, svc dao.Service, helperService utils.Helpe
 	publicAppRouter.Use(userAuthInterceptor.UserAuthenticationIntercept, interceptors.EmailAuthIntercept, interceptors.InsolvencyPermissionsIntercept)
 
 	// Declare endpoint URIs
-	publicAppRouter.Handle("/{transaction_id}/insolvency", HandleCreateInsolvencyResource(svc, helperService)).Methods(http.MethodPost).Name("createInsolvencyResource")
+	publicAppRouter.Handle(insolvencyPath, HandleCreateInsolvencyResource(svc, helperService)).Methods(http.MethodPost).Name("createInsolvencyResource")
 
-	publicAppRouter.Handle("/{transaction_id}/insolvency/validation-status", HandleGetValidationStatus(svc)).Methods(http.MethodGet).Name("getValidationStatus")
+	publicAppRouter.Handle(insolvencyPath+"/validation-status", HandleGetValidationStatus(svc)).Methods(http.MethodGet).Name("getValidationStatus")
 
-	publicAppRouter.Handle("/{transaction_id}/insolvency/practitioners", HandleCreatePractitionersResource(svc, helperService)).Methods(http.MethodPost).Name("createPractitionersResource")
-	publicAppRouter.Handle("/{transaction_id}/insolvency/practitioners", HandleGetPractitionerResources(svc)).Methods(http.MethodGet).Name("getPractitionerResources")
-	publicAppRouter.Handle("/{transaction_id}/insolvency/practitioners/{practitioner_id}", HandleDeletePractitioner(svc)).Methods(http.MethodDelete).Name("deletePractitioner")
-	publicAppRouter.Handle("/{transaction_id}/insolvency/practitioners/{practitioner_id}", HandleGetPractitionerResource(svc)).Methods(http.MethodGet).Name("getPractitionerResource")
+	publicAppRouter.Handle(insolvencyPath+"/practitioners", HandleCreatePractitionersResource(svc, helperService)).Methods(http.MethodPost).Name("createPractitionersResource")
+	publicAppRouter.Handle(insolvencyPath+"/practitioners", HandleGetPractitionerResources(svc)).Methods(http.MethodGet).Name("getPractitionerResources")
+	publicAppRouter.Handle(insolvencyPath+"/practitioners/{practitioner_id}", HandleDeletePractitioner(svc)).Methods(http.MethodDelete).Name("deletePractitioner")
+	publicAppRouter.Handle(insolvencyPath+"/practitioners/{practitioner_id}", HandleGetPractitionerResource(svc)).Methods(http.MethodGet).Name("getPractitionerResource")
 
-	publicAppRouter.Handle("/{transaction_id}/insolvency/practitioners/{practitioner_id}/appointment", HandleAppointPractitioner(svc, helperService)).Methods(http.MethodPost).Name("appointPractitioner")
-	publicAppRouter.Handle("/{transaction_id}/insolvency/practitioners/{practitioner_id}/appointment", HandleGetPractitionerAppointment(svc)).Methods(http.MethodGet).Name("getPractitionerAppointment")
-	publicAppRouter.Handle("/{transaction_id}/insolvency/practitioners/{practitioner_id}/appointment", HandleDeletePractitionerAppointment(svc)).Methods(http.MethodDelete).Name("deletePractitionerAppointment")
+	publicAppRouter.Handle(insolvencyPath+"/practitioners/{practitioner_id}/appointment", HandleAppointPractitioner(svc, helperService)).Methods(http.MethodPost).Name("appointPractitioner")
+	publicAppRouter.Handle(insolvencyPath+"/practitioners/{practitioner_id}/appointment", HandleGetPractitionerAppointment(svc)).Methods(http.MethodGet).Name("getPractitionerAppointment")
+	publicAppRouter.Handle(insolvencyPath+"/practitioners/{practitioner_id}/appointment", HandleDeletePractitionerAppointment(svc)).Methods(http.MethodDelete).Name("deletePractitionerAppointment")
 
-	publicAppRouter.Handle("/{transaction_id}/insolvency/attachments", HandleSubmitAttachment(svc, helperService)).Methods(http.MethodPost).Name("submitAttachment")
-	publicAppRouter.Handle("/{transaction_id}/insolvency/attachments/{attachment_id}", HandleGetAttachmentDetails(svc, helperService)).Methods(http.MethodGet).Name("getAttachmentDetails")
-	publicAppRouter.Handle("/{transaction_id}/insolvency/attachments/{attachment_id}/download", HandleDownloadAttachment(svc)).Methods(http.MethodGet).Name("downloadAttachment")
-	publicAppRouter.Handle("/{transaction_id}/insolvency/attachments/{attachment_id}", HandleDeleteAttachment(svc)).Methods(http.MethodDelete).Name("deleteAttachment")
+	publicAppRouter.Handle(attachmentsPath, HandleSubmitAttachment(svc, helperService)).Methods(http.MethodPost).Name("submitAttachment")
+	publicAppRouter.Handle(specificAttachmentPath, HandleGetAttachmentDetails(svc, helperService)).Methods(http.MethodGet).Name("getAttachmentDetails")
+	publicAppRouter.Handle(specificAttachmentPath+"/download", HandleDownloadAttachment(svc)).Methods(http.MethodGet).Name("downloadAttachment")
+	publicAppRouter.Handle(specificAttachmentPath, HandleDeleteAttachment(svc)).Methods(http.MethodDelete).Name("deleteAttachment")
 
-	publicAppRouter.Handle("/{transaction_id}/insolvency/resolution", HandleCreateResolution(svc, helperService)).Methods(http.MethodPost).Name("createResolution")
-	publicAppRouter.Handle("/{transaction_id}/insolvency/resolution", HandleGetResolution(svc)).Methods(http.MethodGet).Name("getResolution")
-	publicAppRouter.Handle("/{transaction_id}/insolvency/resolution", HandleDeleteResolution(svc)).Methods(http.MethodDelete).Name("deleteResolution")
+	publicAppRouter.Handle(insolvencyPath+"/resolution", HandleCreateResolution(svc, helperService)).Methods(http.MethodPost).Name("createResolution")
+	publicAppRouter.Handle(insolvencyPath+"/resolution", HandleGetResolution(svc)).Methods(http.MethodGet).Name("getResolution")
+	publicAppRouter.Handle(insolvencyPath+"/resolution", HandleDeleteResolution(svc)).Methods(http.MethodDelete).Name("deleteResolution")
 
-	publicAppRouter.Handle("/{transaction_id}/insolvency/statement-of-affairs", HandleCreateStatementOfAffairs(svc, helperService)).Methods(http.MethodPost).Name("createStatementOfAffairs")
-	publicAppRouter.Handle("/{transaction_id}/insolvency/statement-of-affairs", HandleGetStatementOfAffairs(svc)).Methods(http.MethodGet).Name("getStatementOfAffairs")
-	publicAppRouter.Handle("/{transaction_id}/insolvency/statement-of-affairs", HandleDeleteStatementOfAffairs(svc)).Methods(http.MethodDelete).Name("deleteStatementOfAffairs")
+	publicAppRouter.Handle(insolvencyPath+"/statement-of-affairs", HandleCreateStatementOfAffairs(svc, helperService)).Methods(http.MethodPost).Name("createStatementOfAffairs")
+	publicAppRouter.Handle(insolvencyPath+"/statement-of-affairs", HandleGetStatementOfAffairs(svc)).Methods(http.MethodGet).Name("getStatementOfAffairs")
+	publicAppRouter.Handle(insolvencyPath+"/statement-of-affairs", HandleDeleteStatementOfAffairs(svc)).Methods(http.MethodDelete).Name("deleteStatementOfAffairs")
 
 	// Get environment config - only required whilst feature flag in use to disable
 	// non-live form handling routes unless set to true
@@ -68,9 +75,9 @@ func Register(mainRouter *mux.Router, svc dao.Service, helperService utils.Helpe
 	if err != nil {
 		log.Info("Failed to get config for EnableNonLiveRouteHandlers")
 	} else if cfg.EnableNonLiveRouteHandlers {
-		publicAppRouter.Handle("/{transaction_id}/insolvency/progress-report", HandleCreateProgressReport(svc, helperService)).Methods(http.MethodPost).Name("createProgressReport")
-		publicAppRouter.Handle("/{transaction_id}/insolvency/progress-report", HandleGetProgressReport(svc)).Methods(http.MethodGet).Name("getProgressReport")
-		publicAppRouter.Handle("/{transaction_id}/insolvency/progress-report", HandleDeleteProgressReport(svc, helperService)).Methods(http.MethodDelete).Name("deleteProgressReport")
+		publicAppRouter.Handle(insolvencyPath+"/progress-report", HandleCreateProgressReport(svc, helperService)).Methods(http.MethodPost).Name("createProgressReport")
+		publicAppRouter.Handle(insolvencyPath+"/progress-report", HandleGetProgressReport(svc)).Methods(http.MethodGet).Name("getProgressReport")
+		publicAppRouter.Handle(insolvencyPath+"/progress-report", HandleDeleteProgressReport(svc, helperService)).Methods(http.MethodDelete).Name("deleteProgressReport")
 	} else {
 		log.Info("Non-live endpoints blocked")
 	}
@@ -79,7 +86,7 @@ func Register(mainRouter *mux.Router, svc dao.Service, helperService utils.Helpe
 	privateAppRouter := mainRouter.PathPrefix("/private").Subrouter()
 	privateAppRouter.Use(privateUserAuthInterceptor.UserAuthenticationIntercept)
 
-	privateAppRouter.Handle(constants.TransactionsPath+"{transaction_id}/insolvency/filings", HandleGetFilings(svc)).Methods(http.MethodGet).Name("getFilings")
+	privateAppRouter.Handle("/transactions"+insolvencyPath+"/filings", HandleGetFilings(svc)).Methods(http.MethodGet).Name("getFilings")
 
 	mainRouter.Use(log.Handler)
 	mainRouter.Use(RecoveryHandler)

--- a/handlers/register_test.go
+++ b/handlers/register_test.go
@@ -7,22 +7,28 @@ import (
 
 	"github.com/companieshouse/insolvency-api/config"
 	mock_dao "github.com/companieshouse/insolvency-api/mocks"
+	"github.com/companieshouse/insolvency-api/utils"
 	"github.com/golang/mock/gomock"
 	"github.com/gorilla/mux"
 	. "github.com/smartystreets/goconvey/convey"
 )
+
+func setupTestRouter(t *testing.T) *mux.Router {
+	router := mux.NewRouter()
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	mockService := mock_dao.NewMockService(mockCtrl)
+	helperService := utils.NewHelperService()
+	Register(router, mockService, helperService)
+	return router
+}
 
 func TestUnitRegisterRoutes(t *testing.T) {
 	// Certain routes are now disabled when ENABLE_NON_LIVE_ROUTE_HANDLERS is unset or false
 	cfg, _ := config.Get()
 
 	Convey("Register routes: ENABLE_NON_LIVE_ROUTE_HANDLERS unset or false", t, func() {
-		router := mux.NewRouter()
-		mockCtrl := gomock.NewController(t)
-		defer mockCtrl.Finish()
-		mockService := mock_dao.NewMockService(mockCtrl)
-		mockHelperService := mock_dao.NewHelperMockHelperService(mockCtrl)
-		Register(router, mockService, mockHelperService)
+		router := setupTestRouter(t)
 
 		So(router.GetRoute("healthcheck"), ShouldNotBeNil)
 
@@ -59,12 +65,7 @@ func TestUnitRegisterRoutes(t *testing.T) {
 	// Simulate ENABLE_NON_LIVE_ROUTE_HANDLERS feature toggle being enabled
 	cfg.EnableNonLiveRouteHandlers = true
 	Convey("Register routes: ENABLE_NON_LIVE_ROUTE_HANDLERS is set as true", t, func() {
-		router := mux.NewRouter()
-		mockCtrl := gomock.NewController(t)
-		defer mockCtrl.Finish()
-		mockService := mock_dao.NewMockService(mockCtrl)
-		mockHelperService := mock_dao.NewHelperMockHelperService(mockCtrl)
-		Register(router, mockService, mockHelperService)
+		router := setupTestRouter(t)
 
 		So(router.GetRoute("healthcheck"), ShouldNotBeNil)
 
@@ -108,5 +109,34 @@ func TestUnitHealthCheck(t *testing.T) {
 		w := httptest.ResponseRecorder{}
 		healthCheck(&w, nil)
 		So(w.Code, ShouldEqual, http.StatusOK)
+	})
+}
+
+func TestUnitUrlParameterValidation(t *testing.T) {
+	router := setupTestRouter(t)
+	matchInfo := &mux.RouteMatch{}
+	Convey("Invalid Transaction ID matched to route", t, func() {
+		req, _ := http.NewRequest("GET", "/transactions/x/insolvency/validation-status", nil)
+		matched := router.Match(req, matchInfo)
+		So(matched, ShouldEqual, false)
+		So(matchInfo.MatchErr, ShouldEqual, mux.ErrNotFound)
+	})
+	Convey("Valid Transaction ID matched to route", t, func() {
+		req, _ := http.NewRequest("GET", "/transactions/068925-439616-777491/insolvency/validation-status", nil)
+		matched := router.Match(req, matchInfo)
+		So(matched, ShouldEqual, true)
+		So(matchInfo.MatchErr, ShouldBeNil)
+	})
+	Convey("Invalid Attachment ID matched to route", t, func() {
+		req, _ := http.NewRequest("GET", "/transactions/068925-439616-777491/insolvency/attachments/x", nil)
+		matched := router.Match(req, matchInfo)
+		So(matched, ShouldEqual, false)
+		So(matchInfo.MatchErr, ShouldEqual, mux.ErrNotFound)
+	})
+	Convey("Valid Attachment ID matched to route", t, func() {
+		req, _ := http.NewRequest("GET", "/transactions/068925-439616-777491/insolvency/attachments/36bd074f-96a8-46d7-ad6b-29dd67452f0a", nil)
+		matched := router.Match(req, matchInfo)
+		So(matched, ShouldEqual, true)
+		So(matchInfo.MatchErr, ShouldBeNil)
 	})
 }

--- a/models/request_entities.go
+++ b/models/request_entities.go
@@ -2,7 +2,7 @@ package models
 
 // InsolvencyRequest is the model that should be sent to the insolvency API when creating a new request.
 type InsolvencyRequest struct {
-	CompanyNumber string `json:"company_number" validate:"required"`
+	CompanyNumber string `json:"company_number" validate:"required,alphanum"`
 	CompanyName   string `json:"company_name" validate:"required"`
 	CaseType      string `json:"case_type" validate:"required"`
 }


### PR DESCRIPTION
Additional validation added for:
* company_number (request body parameter) - adding 'alphanum' validation on request model struct (ASCII alphanumeric characters only)
* transaction id (url parameter) - adding regex on mux var definition (digits 0-9 plus dash)
* attachment_id (url parameter) - added regex on mux var defintion - uuid so can only contain a-f plus 0-9 plus dash