### PR TITLE
Change to the validation rules when submitting resolution and statement of affairs dates together

### DIFF
--- a/service/insolvency_service.go
+++ b/service/insolvency_service.go
@@ -217,7 +217,7 @@ func checkValidStatementOfAffairsDate(statementOfAffairsDate string, resolutionD
 		return false, "", "resolution date", fmt.Errorf("invalid resolution date [%s]", resolutionDate)
 	}
 
-	// Statement of Affairs Date must be on or before the resolution date
+	// Statement of Affairs Date cannot be after the resolution date
 	if soaDate.After(resDate) {
 		return false, "error - statement of affairs date [" + statementOfAffairsDate + "] must not be after the resolution date" + " [" + resolutionDate + "]", "", nil
 	}

--- a/service/insolvency_service.go
+++ b/service/insolvency_service.go
@@ -217,14 +217,13 @@ func checkValidStatementOfAffairsDate(statementOfAffairsDate string, resolutionD
 		return false, "", "resolution date", fmt.Errorf("invalid resolution date [%s]", resolutionDate)
 	}
 
-	// Statement Of Affairs Date must not be before Resolution Date
-	if soaDate.Before(resDate) {
-		return false, "error - statement of affairs date must not be before resolution date", "", nil
+	// Statement of Affairs Date must be on or before the resolution date
+	if soaDate.After(resDate) {
+		return false, "error - statement of affairs date [" + statementOfAffairsDate + "] must not be after the resolution date" + " [" + resolutionDate + "]", "", nil
 	}
-
-	// Statement Of Affairs Date must not be more than 7 days after resolution date
-	if soaDate.Sub(resDate).Hours()/24 > 7 {
-		return false, "error - statement of affairs date must be within 7 days of resolution date", "", nil
+	// Statement Of Affairs Date must be within 14 days prior to the resolution date
+	if resDate.Sub(soaDate).Hours()/24 > 14 {
+		return false, "error - statement of affairs date [" + statementOfAffairsDate + "] must not be more than 14 days prior to the resolution date" + " [" + resolutionDate + "]", "", nil
 	}
 
 	return true, "", "", nil

--- a/service/insolvency_service_test.go
+++ b/service/insolvency_service_test.go
@@ -613,24 +613,34 @@ func TestUnitValidateInsolvencyDetails(t *testing.T) {
 			So((*validationErrors)[0].Error, ShouldContainSubstring, "invalid resolution date")
 		})
 
-		Convey("Statement date before resolution date", func() {
+		Convey("Statement date is after the resolution date", func() {
 			insolvencyCase := createInsolvencyResource()
-			insolvencyCase.Data.StatementOfAffairs.StatementDate = "2021-07-20"
-			insolvencyCase.Data.Resolution.DateOfResolution = "2021-07-21"
+			insolvencyCase.Data.StatementOfAffairs.StatementDate = "2021-07-26"
+			insolvencyCase.Data.Resolution.DateOfResolution = "2021-07-25"
 			insolvencyCase.Data.Practitioners = nil // prevent alternative validation execution
 
 			validationErrors := ValidateInsolvencyDetails(insolvencyCase)
-			So((*validationErrors)[0].Error, ShouldContainSubstring, "error - statement of affairs date must not be before resolution date")
+			So((*validationErrors)[0].Error, ShouldContainSubstring, "error - statement of affairs date [" + insolvencyCase.Data.StatementOfAffairs.StatementDate + "] must not be after the resolution date" + " [" + insolvencyCase.Data.Resolution.DateOfResolution + "]")
 		})
 
-		Convey("Statement date > 7 days after resolution date", func() {
+		Convey("Statement date more than 14 days prior to the resolution date", func() {
 			insolvencyCase := createInsolvencyResource()
-			insolvencyCase.Data.StatementOfAffairs.StatementDate = "2021-07-29"
-			insolvencyCase.Data.Resolution.DateOfResolution = "2021-07-21"
+			insolvencyCase.Data.StatementOfAffairs.StatementDate = "2021-07-10"
+			insolvencyCase.Data.Resolution.DateOfResolution = "2021-07-25"
 			insolvencyCase.Data.Practitioners = nil // prevent alternative validation execution
 
 			validationErrors := ValidateInsolvencyDetails(insolvencyCase)
-			So((*validationErrors)[0].Error, ShouldContainSubstring, "error - statement of affairs date must be within 7 days of resolution date")
+			So((*validationErrors)[0].Error, ShouldContainSubstring, "error - statement of affairs date [" + insolvencyCase.Data.StatementOfAffairs.StatementDate + "] must not be more than 14 days prior to the resolution date" + " [" + insolvencyCase.Data.Resolution.DateOfResolution + "]")
+		})
+
+		Convey("Statement date is 14 days prior to the resolution date", func() {
+			insolvencyCase := createInsolvencyResource()
+			insolvencyCase.Data.StatementOfAffairs.StatementDate = "2021-07-11"
+			insolvencyCase.Data.Resolution.DateOfResolution = "2021-07-25"
+			insolvencyCase.Data.Practitioners = nil // prevent alternative validation execution
+
+			validationErrors := ValidateInsolvencyDetails(insolvencyCase)
+			So(validationErrors, ShouldHaveLength, 0)
 		})
 
 	})


### PR DESCRIPTION
Previously, the rules around submitting a resolution and statement of affairs dates together were that the statement date could not be before the resolution date or more than 7 days after the resolution date.
After clarifying, the rules are as follows:

1. Statement date cannot be after the resolution date
2. Statement date cannot be more than 14 days prior to the resolution date

checkValidStatementOfAffairs has been modified to reflect the above and the original rules replaced.
Removed the original unit tests and added 3 new unit tests.