### PR TITLE
new attachment ID limit for statement of affairs date submission

### DIFF
--- a/handlers/soa_resource_test.go
+++ b/handlers/soa_resource_test.go
@@ -225,6 +225,7 @@ func TestUnitHandleCreateStatementOfAffairs(t *testing.T) {
 		statement.Attachments = []string{
 			"1234567890",
 			"0987654321",
+			"8364654564",
 		}
 
 		body, _ := json.Marshal(statement)
@@ -233,7 +234,7 @@ func TestUnitHandleCreateStatementOfAffairs(t *testing.T) {
 		res := serveHandleCreateStatementOfAffairs(body, mockService, helperService, true, rec)
 
 		So(res.Code, ShouldEqual, http.StatusBadRequest)
-		So(res.Body.String(), ShouldContainSubstring, "please supply only one attachment")
+		So(res.Body.String(), ShouldContainSubstring, "please supply at least one attachment ID (up to a maximum of two attachment IDs)")
 	})
 
 	Convey("Validation errors are present - no attachment is present", t, func() {
@@ -254,7 +255,7 @@ func TestUnitHandleCreateStatementOfAffairs(t *testing.T) {
 		res := serveHandleCreateStatementOfAffairs(body, mockService, helperService, true, rec)
 
 		So(res.Code, ShouldEqual, http.StatusBadRequest)
-		So(res.Body.String(), ShouldContainSubstring, "please supply only one attachment")
+		So(res.Body.String(), ShouldContainSubstring, "please supply at least one attachment ID (up to a maximum of two attachment IDs)")
 	})
 
 	Convey("Attachment is not of type statement-of-affairs-director, liquidator or concurrence", t, func() {

--- a/handlers/soa_resource_test.go
+++ b/handlers/soa_resource_test.go
@@ -234,7 +234,7 @@ func TestUnitHandleCreateStatementOfAffairs(t *testing.T) {
 		res := serveHandleCreateStatementOfAffairs(body, mockService, helperService, true, rec)
 
 		So(res.Code, ShouldEqual, http.StatusBadRequest)
-		So(res.Body.String(), ShouldContainSubstring, "please supply at least one attachment ID (up to a maximum of two attachment IDs)")
+		So(res.Body.String(), ShouldContainSubstring, "please supply a maximum of two attachments")
 	})
 
 	Convey("Validation errors are present - no attachment is present", t, func() {
@@ -255,7 +255,7 @@ func TestUnitHandleCreateStatementOfAffairs(t *testing.T) {
 		res := serveHandleCreateStatementOfAffairs(body, mockService, helperService, true, rec)
 
 		So(res.Code, ShouldEqual, http.StatusBadRequest)
-		So(res.Body.String(), ShouldContainSubstring, "please supply at least one attachment ID (up to a maximum of two attachment IDs)")
+		So(res.Body.String(), ShouldContainSubstring, "please supply a maximum of two attachments")
 	})
 
 	Convey("Attachment is not of type statement-of-affairs-director, liquidator or concurrence", t, func() {

--- a/service/soa_service.go
+++ b/service/soa_service.go
@@ -23,7 +23,7 @@ func ValidateStatementDetails(svc dao.Service, statementDao *models.StatementOfA
 
 	// Check that the attachment has been submitted correctly
 	if len(statementDao.Attachments) == 0 || len(statementDao.Attachments) > 2 {
-		errs = append(errs, "please supply at least one attachment ID (up to a maximum of two attachment IDs)")
+		errs = append(errs, "please supply a maximum of two attachments")
 	}
 
 	// Check if statement date supplied is in the future or before company was incorporated

--- a/service/soa_service.go
+++ b/service/soa_service.go
@@ -22,8 +22,8 @@ func ValidateStatementDetails(svc dao.Service, statementDao *models.StatementOfA
 	}
 
 	// Check that the attachment has been submitted correctly
-	if len(statementDao.Attachments) == 0 || len(statementDao.Attachments) > 1 {
-		errs = append(errs, "please supply only one attachment")
+	if len(statementDao.Attachments) == 0 || len(statementDao.Attachments) > 2 {
+		errs = append(errs, "please supply at least one attachment ID (up to a maximum of two attachment IDs)")
 	}
 
 	// Check if statement date supplied is in the future or before company was incorporated

--- a/service/soa_service_test.go
+++ b/service/soa_service_test.go
@@ -36,7 +36,7 @@ func TestUnitIsValidStatementDate(t *testing.T) {
 
 		validationErr, err := ValidateStatementDetails(mockService, &statement, transactionID, req)
 
-		So(validationErr, ShouldContainSubstring, "please supply at least one attachment ID (up to a maximum of two attachment IDs)")
+		So(validationErr, ShouldContainSubstring, "please supply a maximum of two attachments")
 		So(err, ShouldBeNil)
 	})
 
@@ -59,7 +59,7 @@ func TestUnitIsValidStatementDate(t *testing.T) {
 
 		validationErr, err := ValidateStatementDetails(mockService, &statement, transactionID, req)
 
-		So(validationErr, ShouldContainSubstring, "please supply at least one attachment ID (up to a maximum of two attachment IDs)")
+		So(validationErr, ShouldContainSubstring, "please supply a maximum of two attachments")
 		So(err, ShouldBeNil)
 	})
 

--- a/service/soa_service_test.go
+++ b/service/soa_service_test.go
@@ -36,11 +36,11 @@ func TestUnitIsValidStatementDate(t *testing.T) {
 
 		validationErr, err := ValidateStatementDetails(mockService, &statement, transactionID, req)
 
-		So(validationErr, ShouldContainSubstring, "please supply only one attachment")
+		So(validationErr, ShouldContainSubstring, "please supply at least one attachment ID (up to a maximum of two attachment IDs)")
 		So(err, ShouldBeNil)
 	})
 
-	Convey("request supplied is invalid - more than one attachment has been supplied", t, func() {
+	Convey("request supplied is invalid - more than two attachments have been supplied", t, func() {
 		mockCtrl := gomock.NewController(t)
 		defer mockCtrl.Finish()
 
@@ -54,12 +54,36 @@ func TestUnitIsValidStatementDate(t *testing.T) {
 		statement.Attachments = []string{
 			"1234567890",
 			"0987654321",
+			"2468097531",
 		}
 
 		validationErr, err := ValidateStatementDetails(mockService, &statement, transactionID, req)
 
-		So(validationErr, ShouldContainSubstring, "please supply only one attachment")
+		So(validationErr, ShouldContainSubstring, "please supply at least one attachment ID (up to a maximum of two attachment IDs)")
 		So(err, ShouldBeNil)
+	})
+
+	Convey("valid request supplied - a minimum of one and a maximum of two attachments have been supplied", t, func() {
+		mockCtrl := gomock.NewController(t)
+		defer mockCtrl.Finish()
+
+		defer httpmock.Reset()
+		httpmock.RegisterResponder(http.MethodGet, apiURL+"/company/1234", httpmock.NewStringResponder(http.StatusOK, companyProfileDateResponse("2000-06-26 00:00:00.000Z")))
+
+		statement := generateStatement()
+		i := 1
+		for i <= 2 {
+			mockService := mocks.NewMockService(mockCtrl)
+			mockService.EXPECT().GetInsolvencyResource(transactionID).Return(generateInsolvencyResource(), nil)
+
+			validationErr, err := ValidateStatementDetails(mockService, &statement, transactionID, req)
+			So(validationErr, ShouldBeEmpty)
+			So(err, ShouldBeNil)
+			attachID := fmt.Sprintf("098765432%d", i)
+			statement.Attachments = append(statement.Attachments, attachID)
+			i = i + 1
+		}
+
 	})
 
 	Convey("error retrieving insolvency resource", t, func() {


### PR DESCRIPTION
1. Changed the rule limiting the number of attachments permitted from one to two.
2. Modified the error message to provide better guidance.
3. Updated the unit tests to include valid tests for submitting one and two attachments.