### PR TITLE
Store practitioner links as map [IEP-779]

### DIFF
--- a/dao/mongo.go
+++ b/dao/mongo.go
@@ -136,9 +136,9 @@ func (m *MongoService) GetInsolvencyPractitionersResource(transactionID string) 
 	}
 
 	// make a call to get insolvency practitioner details
-	practitionersString := insolvencyResourceDao.Data.Practitioners
-	if len(practitionersString) > 0 {
-		practitionerResourceDaos, err := getInsolvencyPractitionersDetails(practitionersString, transactionID, practitionerCollection)
+	if insolvencyResourceDao.Data.Practitioners != nil {
+		practitionerLinksMap := *insolvencyResourceDao.Data.Practitioners
+		practitionerResourceDaos, err := getInsolvencyPractitionersDetails(practitionerLinksMap, transactionID, practitionerCollection)
 		if err != nil {
 			log.Error(err)
 			return nil, nil, fmt.Errorf("there was a problem getting insolvency and practitioners' details for transaction [%s]", err)
@@ -269,18 +269,19 @@ func (m *MongoService) DeletePractitioner(practitionerID string, transactionID s
 		return http.StatusInternalServerError, err
 	}
 
-	// get insolvency practitioners
-	mappedInsolvencyPractitioners, _, err := utils.ConvertStringToMapObjectAndStringList(insolvencyResource.Data.Practitioners)
-	if err != nil {
-		log.Error(err)
+	if insolvencyResource.Data.Practitioners == nil {
+		log.Debug("Cannot delete practitioner - no practitioners found for insolvency case", log.Data{"transaction_id": transactionID})
 		return http.StatusBadRequest, fmt.Errorf("there was a problem handling your request for transaction id %s no insolvency practitioners found", transactionID)
 	}
 
+	// get insolvency practitioner links
+	practitionerLinksMap := *insolvencyResource.Data.Practitioners
+
 	// check if practitionerID exists
-	_, isPresent := mappedInsolvencyPractitioners[practitionerID]
+	_, isPresent := practitionerLinksMap[practitionerID]
 	if isPresent {
-		// delete slice out the practitioner to delete from the map before updating insolvency
-		delete(mappedInsolvencyPractitioners, practitionerID)
+		// delete the practitioner from the map before updating insolvency
+		delete(practitionerLinksMap, practitionerID)
 
 		// delete practitioner appointment
 		filterAppointmentToDelete := bson.M{"practitioner_id": practitionerID}
@@ -303,13 +304,12 @@ func (m *MongoService) DeletePractitioner(practitionerID string, transactionID s
 		}
 
 		// update insolvency
-		remainingPractitionerString, _ := utils.ConvertMapToString(mappedInsolvencyPractitioners)
 
 		insolvencyToUpdate := bson.M{"transaction_id": transactionID}
-		if remainingPractitionerString == "{}" {
+		if len(practitionerLinksMap) == 0 {
 			insolvencyDocumentToUpdate = bson.M{"$unset": bson.M{"data.practitioners": ""}}
 		} else {
-			insolvencyDocumentToUpdate = bson.M{"$set": bson.M{"data.practitioners": remainingPractitionerString}}
+			insolvencyDocumentToUpdate = bson.M{"$set": bson.M{"data.practitioners": practitionerLinksMap}}
 		}
 
 		statusCode, err := updateCollection(insolvencyToUpdate, insolvencyDocumentToUpdate, collection)
@@ -326,28 +326,16 @@ func (m *MongoService) DeletePractitioner(practitionerID string, transactionID s
 
 // UpdatePractitionerAppointment adds appointment details into practitioner case with the specified transactionID and practitionerID
 func (m *MongoService) UpdatePractitionerAppointment(appointmentResourceDao *models.AppointmentResourceDao, transactionID string, practitionerID string) (int, error) {
-	//var practitionerMapAppointmentResource map[string]string
-	practitionerMapAppointmentResource := make(map[string]string)
 
 	// practitioner collection
 	practitionerCollection := m.db.Collection(PractitionerCollectionName)
 
-	// Create appointment link for a practitoner to be stored
-	practitionerMapAppointmentResource[practitionerID] = appointmentResourceDao.Data.Links.Self
-
-	// Convert the map to string
-	appointmentLinks, err := utils.ConvertMapToString(practitionerMapAppointmentResource)
-	if err != nil {
-		log.Error(err)
-		return http.StatusInternalServerError, fmt.Errorf("there was a problem handling your request for transaction id %s - not able to convert mapped practitioner's appointment to string %s", transactionID, practitionerID)
-	}
-
-	// Choose specific practitioner to update with appointment
+	// Select specific practitioner and specify appointment link to add
 	practitionerToUpdate := bson.M{"data.practitioner_id": practitionerID}
-	pratitionerDocumentToUpdate := bson.M{"$set": bson.M{"data.links.appointment": appointmentLinks}}
+	practitionerDocumentToUpdate := bson.M{"$set": bson.M{"data.links.appointment": appointmentResourceDao.Data.Links.Self}}
 
 	//update practitioner collection with appointment link
-	status, err := updateCollection(practitionerToUpdate, pratitionerDocumentToUpdate, practitionerCollection)
+	status, err := updateCollection(practitionerToUpdate, practitionerDocumentToUpdate, practitionerCollection)
 	if err != nil {
 		log.Error(err)
 		return status, fmt.Errorf("there was a problem handling your request for transaction id %s - not able to update practitioner's appointment %s", transactionID, practitionerID)
@@ -386,19 +374,14 @@ func (m *MongoService) DeletePractitionerAppointment(transactionID string, pract
 	}
 
 	// get practitioner appointment(s)
-	mappedPractitionerAppointment, _, err := utils.ConvertStringToMapObjectAndStringList(practitionerResourceDao.Data.Links.Appointment)
-	if err != nil {
-		log.Error(err)
+	if practitionerResourceDao.Data.Links.Appointment == "" {
+		log.Debug("Cannot delete practitioner appointment - no appointment found for practitioner", log.Data{"transaction_id": transactionID})
 		return http.StatusNotFound, fmt.Errorf("there was a problem handling your request for transaction id %s - no practitioner's appointment found", transactionID)
 	}
 
-	// check if practitionerID exists and validate transactionID
-	value, isPresent := mappedPractitionerAppointment[practitionerID]
-	hasValidTransactionID := utils.CheckStringContainsElement(value, "/", transactionID)
+	hasValidTransactionID := utils.CheckStringContainsElement(practitionerResourceDao.Data.Links.Appointment, "/", transactionID)
 
-	if isPresent && hasValidTransactionID {
-		// remove unwanted appointment from the slice
-		delete(mappedPractitionerAppointment, practitionerID)
+	if hasValidTransactionID {
 
 		//delete appointment
 		filterAppointmentToDelete := bson.M{"practitioner_id": practitionerID}
@@ -408,15 +391,9 @@ func (m *MongoService) DeletePractitionerAppointment(transactionID string, pract
 			return http.StatusInternalServerError, fmt.Errorf("there was a problem handling your request for transaction id %s - not able to delete practitioners appointment", transactionID)
 		}
 
-		//update practitioners
-		practitionerAppointmentString, _ := utils.ConvertMapToString(mappedPractitionerAppointment)
-
+		//remove appointment link from practitioner
 		practitionerToUpdate := bson.M{"data.practitioner_id": practitionerID}
-		if practitionerAppointmentString == "{}" {
-			practitionerDocumentToUpdate = bson.M{"$unset": bson.M{"data.links.appointment": ""}}
-		} else {
-			practitionerDocumentToUpdate = bson.M{"$set": bson.M{"data.links.appointment": practitionerAppointmentString}}
-		}
+		practitionerDocumentToUpdate = bson.M{"$unset": bson.M{"data.links.appointment": ""}}
 
 		statusCode, err := updateCollection(practitionerToUpdate, practitionerDocumentToUpdate, practitionerCollection)
 		if err != nil {

--- a/dao/mongo_helper.go
+++ b/dao/mongo_helper.go
@@ -39,15 +39,14 @@ func deleteCollection(filter bson.M, collection *mongo.Collection) (*mongo.Delet
 	return result, nil
 }
 
-func getInsolvencyPractitionersDetails(practitionersString string, transactionID string, collection *mongo.Collection) ([]models.PractitionerResourceDao, error) {
-	_, practitionerIDs, err := utils.ConvertStringToMapObjectAndStringList(practitionersString)
-	if err != nil {
-		return nil, err
+func getInsolvencyPractitionersDetails(practitionerLinksMap models.InsolvencyResourcePractitionersDao, transactionID string, collection *mongo.Collection) ([]models.PractitionerResourceDao, error) {
+	practitionerIDs := utils.GetMapKeysAsStringSlice(practitionerLinksMap)
+	if len(practitionerIDs) == 0 {
+		return nil, fmt.Errorf("no practitioners to retrieve")
 	}
 
 	// make a call to fetch all practitioners from the string array
-	var practitionerResourceDao []models.PractitionerResourceDao
-	practitionerResourceDao, err = getPractitioners(practitionerIDs, collection)
+	practitionerResourceDao, err := getPractitioners(practitionerIDs, collection)
 	if err != nil {
 		log.Debug(err.Error(), log.Data{"transaction_id": transactionID})
 		return nil, err

--- a/dao/mongo_helper_test.go
+++ b/dao/mongo_helper_test.go
@@ -1,0 +1,18 @@
+package dao
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnit_getInsolvencyPractitionersDetails(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no practitioners to retrieve", func(t *testing.T) {
+		got, err := getInsolvencyPractitionersDetails(nil, "12345", nil)
+		assert.Equal(t, fmt.Errorf("no practitioners to retrieve"), err)
+		assert.Nil(t, got)
+	})
+}

--- a/dao/service.go
+++ b/dao/service.go
@@ -17,8 +17,8 @@ type Service interface {
 	// CreatePractitionerResource will persist a newly created practitioner resource
 	CreatePractitionerResource(dao *models.PractitionerResourceDao, transactionID string) (int, error)
 
-	// UpdateInsolvencyPractitioners will update insolvency with practitioners resource
-	UpdateInsolvencyPractitioners(practitionersResource models.InsolvencyResourceDao, transactionID string) (int, error)
+	// AddPractitionerToInsolvencyResource will update insolvency by adding a link to a practitioner resource
+	AddPractitionerToInsolvencyResource(practitionerID string, practitionerLink string, transactionID string) (int, error)
 
 	// GetPractitionerAppointment will retrieve a practitioner appointment
 	GetPractitionerAppointment(practitionerID string, transactionID string) (*models.AppointmentResourceDao, error)

--- a/handlers/insolvency_resource_test.go
+++ b/handlers/insolvency_resource_test.go
@@ -139,6 +139,21 @@ func TestUnitHandleCreateInsolvencyResource(t *testing.T) {
 		So(res.Body.String(), ShouldContainSubstring, "company_number is a required field")
 	})
 
+	Convey("Incoming request has invalid company number", t, func() {
+		mockService, _, rec := mock_dao.CreateTestObjects(t)
+
+		body, _ := json.Marshal(&models.InsolvencyRequest{
+			CaseType:      constants.MVL.String(),
+			CompanyName:   companyName,
+			CompanyNumber: "companyNumberWithPercent%",
+		})
+
+		res := serveHandleCreateInsolvencyResource(body, mockService, true, helperService, rec)
+
+		So(res.Code, ShouldEqual, http.StatusBadRequest)
+		So(res.Body.String(), ShouldContainSubstring, "invalid request body: company_number can only contain alphanumeric characters")
+	})
+
 	Convey("Incoming request has company name missing", t, func() {
 		mockService, _, rec := mock_dao.CreateTestObjects(t)
 

--- a/handlers/insolvency_resource_test.go
+++ b/handlers/insolvency_resource_test.go
@@ -515,10 +515,10 @@ func serveHandleGetFilings(service dao.Service, tranIDSet bool) *httptest.Respon
 
 func createInsolvencyResource() *models.InsolvencyResourceDao {
 
-	jsonPractitionersDao := `{
+	insolvencyResourcePractitionersDao := models.InsolvencyResourcePractitionersDao{
 		"VM04221441": "/transactions/168570-809316-704268/insolvency/practitioners/VM04221441",
-		"VM04221442": "/transactions/168570-809316-704268/insolvency/practitioners/VM04221442"
-	}`
+		"VM04221442": "/transactions/168570-809316-704268/insolvency/practitioners/VM04221442",
+	}
 
 	practitionerResourceDao := models.PractitionerResourceDao{}
 	appointmentResourceDao := models.AppointmentResourceDao{}
@@ -536,7 +536,7 @@ func createInsolvencyResource() *models.InsolvencyResourceDao {
 	insolvencyResourceDao.Data.CompanyName = companyName
 	insolvencyResourceDao.Data.CaseType = "insolvency"
 
-	insolvencyResourceDao.Data.Practitioners = jsonPractitionersDao
+	insolvencyResourceDao.Data.Practitioners = &insolvencyResourcePractitionersDao
 	insolvencyResourceDao.Data.Links = models.InsolvencyResourceLinksDao{
 		Self:             "/transactions/123456789/insolvency",
 		ValidationStatus: "/transactions/123456789/insolvency/validation-status",
@@ -722,7 +722,7 @@ func TestUnitHandleGetFilings(t *testing.T) {
 		httpmock.RegisterResponder(http.MethodGet, "https://api.companieshouse.gov.uk/transactions/12345678", httpmock.NewStringResponder(http.StatusOK, transactionProfileResponseClosed))
 
 		insolvencyCase := createInsolvencyResource()
-		insolvencyCase.Data.Practitioners = ""
+		insolvencyCase.Data.Practitioners = nil
 		insolvencyCase.Data.Resolution = &models.ResolutionResourceDao{
 			DateOfResolution: "2021-06-06",
 			Attachments: []string{

--- a/handlers/practitioner_resource_test.go
+++ b/handlers/practitioner_resource_test.go
@@ -470,7 +470,7 @@ func TestUnitHandleCreatePractitionersResource(t *testing.T) {
 		mockService.EXPECT().GetInsolvencyPractitionersResource(gomock.Any()).Return(generateInsolvencyPractitionerAppointmentResources(), nil, nil).Times(2)
 		mockService.EXPECT().GetPractitionersResource(gomock.Any()).Return(practitionerResourceDaos, nil)
 		mockService.EXPECT().CreatePractitionerResource(gomock.Any(), gomock.Any()).Return(200, nil)
-		mockService.EXPECT().UpdateInsolvencyPractitioners(gomock.Any(), gomock.Any()).Return(200, nil)
+		mockService.EXPECT().AddPractitionerToInsolvencyResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(200, nil)
 
 		res := serveHandleCreatePractitionersResource(body, mockService, helperService, true, rec)
 
@@ -509,7 +509,7 @@ func TestUnitHandleCreatePractitionersResource(t *testing.T) {
 		mockService.EXPECT().GetInsolvencyPractitionersResource(gomock.Any()).Return(&dataDto, nil, nil).Times(2)
 		mockService.EXPECT().GetPractitionersResource(gomock.Any()).Return(practitionerResourceDaos, nil)
 		mockService.EXPECT().CreatePractitionerResource(gomock.Any(), gomock.Any()).Return(200, nil)
-		mockService.EXPECT().UpdateInsolvencyPractitioners(gomock.Any(), gomock.Any()).Return(404, fmt.Errorf("there was a problem handling your request for transaction id [%s] not found", transactionID))
+		mockService.EXPECT().AddPractitionerToInsolvencyResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(404, fmt.Errorf("there was a problem handling your request for transaction id [%s] not found", transactionID))
 
 		res := serveHandleCreatePractitionersResource(body, mockService, mockHelperService, true, rec)
 
@@ -556,7 +556,7 @@ func TestUnitHandleCreatePractitionersResource(t *testing.T) {
 		mockService.EXPECT().GetInsolvencyPractitionersResource(gomock.Any()).Return(&dataDto, nil, nil).Times(2)
 		mockService.EXPECT().GetPractitionersResource(gomock.Any()).Return(practitionerResourceDaos, nil)
 		mockService.EXPECT().CreatePractitionerResource(gomock.Any(), gomock.Any()).Return(200, nil)
-		mockService.EXPECT().UpdateInsolvencyPractitioners(gomock.Any(), gomock.Any()).Return(200, nil)
+		mockService.EXPECT().AddPractitionerToInsolvencyResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(200, nil)
 
 		res := serveHandleCreatePractitionersResource(body, mockService, mockHelperService, true, rec)
 
@@ -600,7 +600,7 @@ func TestUnitHandleCreatePractitionersResource(t *testing.T) {
 		mockService.EXPECT().GetInsolvencyPractitionersResource(gomock.Any()).Return(insolvencyCase, nil, nil).Times(2)
 		mockService.EXPECT().GetPractitionersResource(gomock.Any()).Return(practitionerResourceDaos, nil)
 		mockService.EXPECT().CreatePractitionerResource(gomock.Any(), gomock.Any()).Return(200, nil)
-		mockService.EXPECT().UpdateInsolvencyPractitioners(gomock.Any(), gomock.Any()).Return(200, nil)
+		mockService.EXPECT().AddPractitionerToInsolvencyResource(gomock.Any(), gomock.Any(), gomock.Any()).Return(200, nil)
 
 		res := serveHandleCreatePractitionersResource(body, mockService, mockHelperService, true, rec)
 

--- a/handlers/practitioner_resource_test.go
+++ b/handlers/practitioner_resource_test.go
@@ -488,7 +488,9 @@ func TestUnitHandleCreatePractitionersResource(t *testing.T) {
 		practitioner := generatePractitioner()
 		body, _ := json.Marshal(practitioner)
 
-		jsonPractitionersDaoMap := `{"VM04221441":  "/transactions/168570-809316-704268/insolvency/practitioners/VM04221441"}`
+		insolvencyResourcePractitionersDao := models.InsolvencyResourcePractitionersDao{
+			"VM04221441": "/transactions/168570-809316-704268/insolvency/practitioners/VM04221441",
+		}
 
 		dataDto := models.InsolvencyResourceDao{}
 		dataDto.Data.CompanyNumber = "company_number"
@@ -496,7 +498,7 @@ func TestUnitHandleCreatePractitionersResource(t *testing.T) {
 		dataDto.Data.CompanyName = "company_name"
 		dataDto.Data.Etag = "etag"
 		dataDto.Data.Kind = "kind"
-		dataDto.Data.Practitioners = jsonPractitionersDaoMap
+		dataDto.Data.Practitioners = &insolvencyResourcePractitionersDao
 
 		mockHelperService.EXPECT().GenerateEtag().Return("etag", nil)
 		mockHelperService.EXPECT().HandleTransactionIdExistsValidation(gomock.Any(), gomock.Any(), transactionID).Return(true, transactionID).AnyTimes()
@@ -520,11 +522,13 @@ func TestUnitHandleCreatePractitionersResource(t *testing.T) {
 		mockService, mockHelperService, rec := mock_dao.CreateTestObjects(t)
 		httpmock.Activate()
 
-		jsonPractitionersDaoMap := `{"VM04221441": "/transactions/168570-809316-704268/insolvency/practitioners/VM04221441",
+		insolvencyResourcePractitionersDao := models.InsolvencyResourcePractitionersDao{
+			"VM04221441": "/transactions/168570-809316-704268/insolvency/practitioners/VM04221441",
 			"VM04221442": "/transactions/168570-809316-704268/insolvency/practitioners/VM04221442",
 			"VM04221444": "/transactions/168570-809316-704268/insolvency/practitioners/VM04221444",
 			"VM04221445": "/transactions/168570-809316-704268/insolvency/practitioners/VM04221445",
-			"VM04221446": "/transactions/168570-809316-704268/insolvency/practitioners/VM04221446"}`
+			"VM04221446": "/transactions/168570-809316-704268/insolvency/practitioners/VM04221446",
+		}
 
 		dataDto := models.InsolvencyResourceDao{}
 		dataDto.Data.CompanyNumber = "company_number"
@@ -532,7 +536,7 @@ func TestUnitHandleCreatePractitionersResource(t *testing.T) {
 		dataDto.Data.CompanyName = "company_name"
 		dataDto.Data.Etag = "etag"
 		dataDto.Data.Kind = "kind"
-		dataDto.Data.Practitioners = jsonPractitionersDaoMap
+		dataDto.Data.Practitioners = &insolvencyResourcePractitionersDao
 
 		// Expect the transaction api to be called and return an open transaction
 		httpmock.RegisterResponder(http.MethodGet, "https://api.companieshouse.gov.uk/transactions/12345678", httpmock.NewStringResponder(http.StatusOK, transactionProfileResponse))
@@ -564,9 +568,11 @@ func TestUnitHandleCreatePractitionersResource(t *testing.T) {
 		mockService, mockHelperService, rec := mock_dao.CreateTestObjects(t)
 		httpmock.Activate()
 
-		jsonPractitionersDaoMap := `{"VM04221441": "/transactions/168570-809316-704268/insolvency/practitioners/VM04221441",
+		insolvencyResourcePractitionersDao := models.InsolvencyResourcePractitionersDao{
+			"VM04221441": "/transactions/168570-809316-704268/insolvency/practitioners/VM04221441",
 			"VM04221442": "/transactions/168570-809316-704268/insolvency/practitioners/VM04221442",
-			"VM04221446": "/transactions/168570-809316-704268/insolvency/practitioners/VM04221446"}`
+			"VM04221446": "/transactions/168570-809316-704268/insolvency/practitioners/VM04221446",
+		}
 
 		dataDto := models.InsolvencyResourceDao{}
 		dataDto.Data.CompanyNumber = "company_number"
@@ -574,7 +580,7 @@ func TestUnitHandleCreatePractitionersResource(t *testing.T) {
 		dataDto.Data.CompanyName = "company_name"
 		dataDto.Data.Etag = "etag"
 		dataDto.Data.Kind = "kind"
-		dataDto.Data.Practitioners = jsonPractitionersDaoMap
+		dataDto.Data.Practitioners = &insolvencyResourcePractitionersDao
 
 		// Expect the transaction api to be called and return an open transaction
 		httpmock.RegisterResponder(http.MethodGet, "https://api.companieshouse.gov.uk/transactions/12345678", httpmock.NewStringResponder(http.StatusOK, transactionProfileResponse))
@@ -705,7 +711,7 @@ func TestUnitHandleGetPractitionerResources(t *testing.T) {
 		insolvencyCase := generateInsolvencyPractitionerAppointmentResources()
 		insolvencyCase.Data.CaseType = constants.CVL.String()
 
-		mockService.EXPECT().GetInsolvencyPractitionersResource(transactionID).Return(nil, nil, nil).Times(1)
+		mockService.EXPECT().GetInsolvencyPractitionersResource(transactionID).Return(insolvencyCase, nil, nil).Times(1)
 		mockService.EXPECT().GetPractitionersResource(gomock.Any()).Return(practitionerResourceDaos, nil).AnyTimes()
 
 		res := serveGetPractitionersByIdssRequest(mockService, true)
@@ -717,13 +723,14 @@ func TestUnitHandleGetPractitionerResources(t *testing.T) {
 		mockCtrl := gomock.NewController(t)
 		defer mockCtrl.Finish()
 
-		jsonPractitionersDaoMap := `
+		insolvencyResourcePractitionersDao := models.InsolvencyResourcePractitionersDao{
 			"VM04221441":  "/transactions/168570-809316-704268/insolvency/practitioners/VM04221441",
 			"VM042214412": "/transactions/168570-809316-704268/insolvency/practitioners/VM042214412",
 			"VM04221443":  "/transactions/168570-809316-704268/insolvency/practitioners/VM042214413",
 			"VM04221444":  "/transactions/168570-809316-704268/insolvency/practitioners/VM04221444",
 			"VM04221445":  "/transactions/168570-809316-704268/insolvency/practitioners/VM04221445",
-			"VM04221446":  "/transactions/168570-809316-704268/insolvency/practitioners/VM04221446"}`
+			"VM04221446":  "/transactions/168570-809316-704268/insolvency/practitioners/VM04221446",
+		}
 
 		dataDto := models.InsolvencyResourceDao{}
 		dataDto.Data.CompanyNumber = "company_number"
@@ -731,7 +738,7 @@ func TestUnitHandleGetPractitionerResources(t *testing.T) {
 		dataDto.Data.CompanyName = "company_name"
 		dataDto.Data.Etag = "etag"
 		dataDto.Data.Kind = "kind"
-		dataDto.Data.Practitioners = jsonPractitionersDaoMap
+		dataDto.Data.Practitioners = &insolvencyResourcePractitionersDao
 
 		mockService := mock_dao.NewMockService(mockCtrl)
 		insolvencyCase := generateInsolvencyPractitionerAppointmentResources()
@@ -1179,8 +1186,8 @@ func TestUnitHandleAppointPractitioner(t *testing.T) {
 		practitionerResourceDao.Data.PractitionerId = practitionerID
 		practitionerResourceDao.Data.Appointment = &appointmentResourceDao
 		practitionerResourceDao.Data.Links = models.PractitionerResourceLinksDao{
-			Self: "/transactions/12345678/insolvency/practitioners/00001234",
-			Appointment: "{\"00001234\":\"/transactions/12345678/insolvency/practitioners/00001234/appointment\"}",
+			Self:        "/transactions/12345678/insolvency/practitioners/00001234",
+			Appointment: "/transactions/12345678/insolvency/practitioners/00001234/appointment",
 		}
 
 		practitionerResourceDaos := append([]models.PractitionerResourceDao{}, practitionerResourceDao)
@@ -1381,7 +1388,6 @@ func TestUnitHandleAppointPractitioner(t *testing.T) {
 		So(res.Code, ShouldEqual, http.StatusBadRequest)
 	})
 
-
 	Convey("successful appointment", t, func() {
 		mockService, mockHelperService, rec := mock_dao.CreateTestObjects(t)
 		httpmock.Activate()
@@ -1581,7 +1587,7 @@ func TestUnitHandleGetPractitionerAppointment(t *testing.T) {
 
 		practitionerResourceDaos[0].Data.PractitionerId = practitionerID
 		practitionerResourceDaos[0].Data.Appointment = &appointmentResourceDao
-		practitionerResourceDaos[0].Data.Links.Appointment = "{\"00001234\":\"/transactions/X/insolvency/practitioners/00001234/appointment\"}"
+		practitionerResourceDaos[0].Data.Links.Appointment = "/transactions/X/insolvency/practitioners/00001234/appointment"
 
 		mockService.EXPECT().GetPractitionersResource(gomock.Any()).Return(practitionerResourceDaos, nil)
 
@@ -1606,7 +1612,7 @@ func TestUnitHandleGetPractitionerAppointment(t *testing.T) {
 
 		practitionerResourceDaos[0].Data.PractitionerId = "practitionerID"
 		practitionerResourceDaos[0].Data.Appointment = &appointmentResourceDao
-		practitionerResourceDaos[0].Data.Links.Appointment = "{\"00001234\":\"/transactions/123456789/insolvency/practitioners/00001234/appointment\"}"
+		practitionerResourceDaos[0].Data.Links.Appointment = "/transactions/123456789/insolvency/practitioners/00001234/appointment"
 
 		mockService.EXPECT().GetPractitionersResource(gomock.Any()).Return(practitionerResourceDaos, nil)
 
@@ -1631,7 +1637,7 @@ func TestUnitHandleGetPractitionerAppointment(t *testing.T) {
 
 		practitionerResourceDaos[0].Data.PractitionerId = practitionerID
 		practitionerResourceDaos[0].Data.Appointment = &appointmentResourceDao
-		practitionerResourceDaos[0].Data.Links.Appointment = "{\"00001234\":\"/transactions/12345678/insolvency/practitioners/00001234/appointment\"}"
+		practitionerResourceDaos[0].Data.Links.Appointment = "00001234\":\"/transactions/12345678/insolvency/practitioners/00001234/appointment"
 
 		mockService.EXPECT().GetPractitionersResource(gomock.Any()).Return(practitionerResourceDaos, nil)
 

--- a/handlers/register.go
+++ b/handlers/register.go
@@ -7,11 +7,22 @@ import (
 	"github.com/companieshouse/chs.go/authentication"
 	"github.com/companieshouse/chs.go/log"
 	"github.com/companieshouse/insolvency-api/config"
-	"github.com/companieshouse/insolvency-api/constants"
 	"github.com/companieshouse/insolvency-api/dao"
 	"github.com/companieshouse/insolvency-api/interceptors"
 	"github.com/companieshouse/insolvency-api/utils"
 	"github.com/gorilla/mux"
+)
+
+const (
+	digitsAndDashRegex     = "[0-9-]+"
+	insolvencyPath         = "/{transaction_id:" + digitsAndDashRegex + "}/insolvency"
+	uuidCharsRegex         = "[a-f0-9-]+"
+	attachmentsPath        = insolvencyPath + "/attachments"
+	specificAttachmentPath = attachmentsPath + "/{attachment_id:" + uuidCharsRegex + "}"
+	appointmentPath        = insolvencyPath + "/practitioners/{practitioner_id}/appointment"
+	resolutionPath         = insolvencyPath + "/resolution"
+	statementOfAffairsPath = insolvencyPath + "/statement-of-affairs"
+	progressReportPath     = insolvencyPath + "/progress-report"
 )
 
 // Register defines the endpoints for the API
@@ -34,31 +45,35 @@ func Register(mainRouter *mux.Router, svc dao.Service, helperService utils.Helpe
 	publicAppRouter.Use(userAuthInterceptor.UserAuthenticationIntercept, interceptors.EmailAuthIntercept, interceptors.InsolvencyPermissionsIntercept)
 
 	// Declare endpoint URIs
-	publicAppRouter.Handle("/{transaction_id}/insolvency", HandleCreateInsolvencyResource(svc, helperService)).Methods(http.MethodPost).Name("createInsolvencyResource")
+	publicAppRouter.Handle(insolvencyPath, HandleCreateInsolvencyResource(svc, helperService)).Methods(http.MethodPost).Name("createInsolvencyResource")
 
-	publicAppRouter.Handle("/{transaction_id}/insolvency/validation-status", HandleGetValidationStatus(svc)).Methods(http.MethodGet).Name("getValidationStatus")
+	publicAppRouter.Handle(insolvencyPath+"/validation-status", HandleGetValidationStatus(svc)).Methods(http.MethodGet).Name("getValidationStatus")
 
-	publicAppRouter.Handle("/{transaction_id}/insolvency/practitioners", HandleCreatePractitionersResource(svc, helperService)).Methods(http.MethodPost).Name("createPractitionersResource")
-	publicAppRouter.Handle("/{transaction_id}/insolvency/practitioners", HandleGetPractitionerResources(svc)).Methods(http.MethodGet).Name("getPractitionerResources")
-	publicAppRouter.Handle("/{transaction_id}/insolvency/practitioners/{practitioner_id}", HandleDeletePractitioner(svc)).Methods(http.MethodDelete).Name("deletePractitioner")
-	publicAppRouter.Handle("/{transaction_id}/insolvency/practitioners/{practitioner_id}", HandleGetPractitionerResource(svc)).Methods(http.MethodGet).Name("getPractitionerResource")
+	publicAppRouter.Handle(insolvencyPath+"/practitioners", HandleCreatePractitionersResource(svc, helperService)).Methods(http.MethodPost).Name("createPractitionersResource")
+	publicAppRouter.Handle(insolvencyPath+"/practitioners", HandleGetPractitionerResources(svc)).Methods(http.MethodGet).Name("getPractitionerResources")
+	publicAppRouter.Handle(insolvencyPath+"/practitioners/{practitioner_id}", HandleDeletePractitioner(svc)).Methods(http.MethodDelete).Name("deletePractitioner")
+	publicAppRouter.Handle(insolvencyPath+"/practitioners/{practitioner_id}", HandleGetPractitionerResource(svc)).Methods(http.MethodGet).Name("getPractitionerResource")
 
-	publicAppRouter.Handle("/{transaction_id}/insolvency/practitioners/{practitioner_id}/appointment", HandleAppointPractitioner(svc, helperService)).Methods(http.MethodPost).Name("appointPractitioner")
-	publicAppRouter.Handle("/{transaction_id}/insolvency/practitioners/{practitioner_id}/appointment", HandleGetPractitionerAppointment(svc)).Methods(http.MethodGet).Name("getPractitionerAppointment")
-	publicAppRouter.Handle("/{transaction_id}/insolvency/practitioners/{practitioner_id}/appointment", HandleDeletePractitionerAppointment(svc)).Methods(http.MethodDelete).Name("deletePractitionerAppointment")
+	publicAppRouter.Handle(appointmentPath, HandleAppointPractitioner(svc, helperService)).Methods(http.MethodPost).Name("appointPractitioner")
+	publicAppRouter.Handle(appointmentPath, HandleGetPractitionerAppointment(svc)).Methods(http.MethodGet).Name("getPractitionerAppointment")
+	publicAppRouter.Handle(appointmentPath, HandleDeletePractitionerAppointment(svc)).Methods(http.MethodDelete).Name("deletePractitionerAppointment")
 
-	publicAppRouter.Handle("/{transaction_id}/insolvency/attachments", HandleSubmitAttachment(svc, helperService)).Methods(http.MethodPost).Name("submitAttachment")
-	publicAppRouter.Handle("/{transaction_id}/insolvency/attachments/{attachment_id}", HandleGetAttachmentDetails(svc, helperService)).Methods(http.MethodGet).Name("getAttachmentDetails")
-	publicAppRouter.Handle("/{transaction_id}/insolvency/attachments/{attachment_id}/download", HandleDownloadAttachment(svc)).Methods(http.MethodGet).Name("downloadAttachment")
-	publicAppRouter.Handle("/{transaction_id}/insolvency/attachments/{attachment_id}", HandleDeleteAttachment(svc)).Methods(http.MethodDelete).Name("deleteAttachment")
+	publicAppRouter.Handle(attachmentsPath, HandleSubmitAttachment(svc, helperService)).Methods(http.MethodPost).Name("submitAttachment")
+	publicAppRouter.Handle(specificAttachmentPath, HandleGetAttachmentDetails(svc, helperService)).Methods(http.MethodGet).Name("getAttachmentDetails")
+	publicAppRouter.Handle(specificAttachmentPath+"/download", HandleDownloadAttachment(svc)).Methods(http.MethodGet).Name("downloadAttachment")
+	publicAppRouter.Handle(specificAttachmentPath, HandleDeleteAttachment(svc)).Methods(http.MethodDelete).Name("deleteAttachment")
 
-	publicAppRouter.Handle("/{transaction_id}/insolvency/resolution", HandleCreateResolution(svc, helperService)).Methods(http.MethodPost).Name("createResolution")
-	publicAppRouter.Handle("/{transaction_id}/insolvency/resolution", HandleGetResolution(svc)).Methods(http.MethodGet).Name("getResolution")
-	publicAppRouter.Handle("/{transaction_id}/insolvency/resolution", HandleDeleteResolution(svc)).Methods(http.MethodDelete).Name("deleteResolution")
+	publicAppRouter.Handle(resolutionPath, HandleCreateResolution(svc, helperService)).Methods(http.MethodPost).Name("createResolution")
+	publicAppRouter.Handle(resolutionPath, HandleGetResolution(svc)).Methods(http.MethodGet).Name("getResolution")
+	publicAppRouter.Handle(resolutionPath, HandleDeleteResolution(svc)).Methods(http.MethodDelete).Name("deleteResolution")
 
-	publicAppRouter.Handle("/{transaction_id}/insolvency/statement-of-affairs", HandleCreateStatementOfAffairs(svc, helperService)).Methods(http.MethodPost).Name("createStatementOfAffairs")
-	publicAppRouter.Handle("/{transaction_id}/insolvency/statement-of-affairs", HandleGetStatementOfAffairs(svc)).Methods(http.MethodGet).Name("getStatementOfAffairs")
-	publicAppRouter.Handle("/{transaction_id}/insolvency/statement-of-affairs", HandleDeleteStatementOfAffairs(svc)).Methods(http.MethodDelete).Name("deleteStatementOfAffairs")
+	publicAppRouter.Handle(statementOfAffairsPath, HandleCreateStatementOfAffairs(svc, helperService)).Methods(http.MethodPost).Name("createStatementOfAffairs")
+	publicAppRouter.Handle(statementOfAffairsPath, HandleGetStatementOfAffairs(svc)).Methods(http.MethodGet).Name("getStatementOfAffairs")
+	publicAppRouter.Handle(statementOfAffairsPath, HandleDeleteStatementOfAffairs(svc)).Methods(http.MethodDelete).Name("deleteStatementOfAffairs")
+
+	publicAppRouter.Handle(progressReportPath, HandleCreateProgressReport(svc, helperService)).Methods(http.MethodPost).Name("createProgressReport")
+	publicAppRouter.Handle(progressReportPath, HandleGetProgressReport(svc)).Methods(http.MethodGet).Name("getProgressReport")
+	publicAppRouter.Handle(progressReportPath, HandleDeleteProgressReport(svc, helperService)).Methods(http.MethodDelete).Name("deleteProgressReport")
 
 	// Get environment config - only required whilst feature flag in use to disable
 	// non-live form handling routes unless set to true
@@ -68,9 +83,8 @@ func Register(mainRouter *mux.Router, svc dao.Service, helperService utils.Helpe
 	if err != nil {
 		log.Info("Failed to get config for EnableNonLiveRouteHandlers")
 	} else if cfg.EnableNonLiveRouteHandlers {
-		publicAppRouter.Handle("/{transaction_id}/insolvency/progress-report", HandleCreateProgressReport(svc, helperService)).Methods(http.MethodPost).Name("createProgressReport")
-		publicAppRouter.Handle("/{transaction_id}/insolvency/progress-report", HandleGetProgressReport(svc)).Methods(http.MethodGet).Name("getProgressReport")
-		publicAppRouter.Handle("/{transaction_id}/insolvency/progress-report", HandleDeleteProgressReport(svc, helperService)).Methods(http.MethodDelete).Name("deleteProgressReport")
+		log.Info("Non-live endpoints enabled")
+		// Register any in-development endpoints here
 	} else {
 		log.Info("Non-live endpoints blocked")
 	}
@@ -79,7 +93,7 @@ func Register(mainRouter *mux.Router, svc dao.Service, helperService utils.Helpe
 	privateAppRouter := mainRouter.PathPrefix("/private").Subrouter()
 	privateAppRouter.Use(privateUserAuthInterceptor.UserAuthenticationIntercept)
 
-	privateAppRouter.Handle(constants.TransactionsPath+"{transaction_id}/insolvency/filings", HandleGetFilings(svc)).Methods(http.MethodGet).Name("getFilings")
+	privateAppRouter.Handle("/transactions"+insolvencyPath+"/filings", HandleGetFilings(svc)).Methods(http.MethodGet).Name("getFilings")
 
 	mainRouter.Use(log.Handler)
 	mainRouter.Use(RecoveryHandler)

--- a/handlers/register_test.go
+++ b/handlers/register_test.go
@@ -7,22 +7,28 @@ import (
 
 	"github.com/companieshouse/insolvency-api/config"
 	mock_dao "github.com/companieshouse/insolvency-api/mocks"
+	"github.com/companieshouse/insolvency-api/utils"
 	"github.com/golang/mock/gomock"
 	"github.com/gorilla/mux"
 	. "github.com/smartystreets/goconvey/convey"
 )
+
+func setupTestRouter(t *testing.T) *mux.Router {
+	router := mux.NewRouter()
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+	mockService := mock_dao.NewMockService(mockCtrl)
+	helperService := utils.NewHelperService()
+	Register(router, mockService, helperService)
+	return router
+}
 
 func TestUnitRegisterRoutes(t *testing.T) {
 	// Certain routes are now disabled when ENABLE_NON_LIVE_ROUTE_HANDLERS is unset or false
 	cfg, _ := config.Get()
 
 	Convey("Register routes: ENABLE_NON_LIVE_ROUTE_HANDLERS unset or false", t, func() {
-		router := mux.NewRouter()
-		mockCtrl := gomock.NewController(t)
-		defer mockCtrl.Finish()
-		mockService := mock_dao.NewMockService(mockCtrl)
-		mockHelperService := mock_dao.NewHelperMockHelperService(mockCtrl)
-		Register(router, mockService, mockHelperService)
+		router := setupTestRouter(t)
 
 		So(router.GetRoute("healthcheck"), ShouldNotBeNil)
 
@@ -52,19 +58,14 @@ func TestUnitRegisterRoutes(t *testing.T) {
 		So(router.GetRoute("getStatementOfAffairs"), ShouldNotBeNil)
 		So(router.GetRoute("deleteStatementOfAffairs"), ShouldNotBeNil)
 
-		So(router.GetRoute("createProgressReport"), ShouldBeNil)
-		So(router.GetRoute("getProgressReport"), ShouldBeNil)
+		So(router.GetRoute("createProgressReport"), ShouldNotBeNil)
+		So(router.GetRoute("getProgressReport"), ShouldNotBeNil)
 	})
 
 	// Simulate ENABLE_NON_LIVE_ROUTE_HANDLERS feature toggle being enabled
 	cfg.EnableNonLiveRouteHandlers = true
 	Convey("Register routes: ENABLE_NON_LIVE_ROUTE_HANDLERS is set as true", t, func() {
-		router := mux.NewRouter()
-		mockCtrl := gomock.NewController(t)
-		defer mockCtrl.Finish()
-		mockService := mock_dao.NewMockService(mockCtrl)
-		mockHelperService := mock_dao.NewHelperMockHelperService(mockCtrl)
-		Register(router, mockService, mockHelperService)
+		router := setupTestRouter(t)
 
 		So(router.GetRoute("healthcheck"), ShouldNotBeNil)
 
@@ -108,5 +109,34 @@ func TestUnitHealthCheck(t *testing.T) {
 		w := httptest.ResponseRecorder{}
 		healthCheck(&w, nil)
 		So(w.Code, ShouldEqual, http.StatusOK)
+	})
+}
+
+func TestUnitUrlParameterValidation(t *testing.T) {
+	router := setupTestRouter(t)
+	matchInfo := &mux.RouteMatch{}
+	Convey("Invalid Transaction ID matched to route", t, func() {
+		req, _ := http.NewRequest("GET", "/transactions/x/insolvency/validation-status", nil)
+		matched := router.Match(req, matchInfo)
+		So(matched, ShouldEqual, false)
+		So(matchInfo.MatchErr, ShouldEqual, mux.ErrNotFound)
+	})
+	Convey("Valid Transaction ID matched to route", t, func() {
+		req, _ := http.NewRequest("GET", "/transactions/068925-439616-777491/insolvency/validation-status", nil)
+		matched := router.Match(req, matchInfo)
+		So(matched, ShouldEqual, true)
+		So(matchInfo.MatchErr, ShouldBeNil)
+	})
+	Convey("Invalid Attachment ID matched to route", t, func() {
+		req, _ := http.NewRequest("GET", "/transactions/068925-439616-777491/insolvency/attachments/x", nil)
+		matched := router.Match(req, matchInfo)
+		So(matched, ShouldEqual, false)
+		So(matchInfo.MatchErr, ShouldEqual, mux.ErrNotFound)
+	})
+	Convey("Valid Attachment ID matched to route", t, func() {
+		req, _ := http.NewRequest("GET", "/transactions/068925-439616-777491/insolvency/attachments/36bd074f-96a8-46d7-ad6b-29dd67452f0a", nil)
+		matched := router.Match(req, matchInfo)
+		So(matched, ShouldEqual, true)
+		So(matchInfo.MatchErr, ShouldBeNil)
 	})
 }

--- a/handlers/soa_resource.go
+++ b/handlers/soa_resource.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/companieshouse/chs.go/log"
+	"github.com/companieshouse/insolvency-api/constants"
 	"github.com/companieshouse/insolvency-api/dao"
 	"github.com/companieshouse/insolvency-api/models"
 	"github.com/companieshouse/insolvency-api/service"
@@ -64,9 +65,9 @@ func HandleCreateStatementOfAffairs(svc dao.Service, helperService utils.HelperS
 		}
 
 		// Validate the supplied attachment is a valid type
-		if attachment.Type != "statement-of-affairs-director" && attachment.Type != "statement-of-affairs-liquidator" {
+		if attachment.Type != constants.StatementOfAffairsDirector.String() && attachment.Type != constants.StatementOfAffairsLiquidator.String() && attachment.Type != constants.StatementOfConcurrence.String() {
 			err := fmt.Errorf("attachment id [%s] is an invalid type for this request: %v", statementDao.Attachments[0], attachment.Type)
-			responseMessage := "attachment is not a statement-of-affairs-director or statement-of-affairs-liquidator"
+			responseMessage := ("attachment is not a " + constants.StatementOfAffairsDirector.String() + ", " + constants.StatementOfAffairsLiquidator.String() + " or a " + constants.StatementOfConcurrence.String())
 
 			helperService.HandleAttachmentTypeValidation(w, req, responseMessage, err)
 			return

--- a/handlers/soa_resource_test.go
+++ b/handlers/soa_resource_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/companieshouse/chs.go/log"
+	"github.com/companieshouse/insolvency-api/constants"
 	"github.com/companieshouse/insolvency-api/dao"
 	mock_dao "github.com/companieshouse/insolvency-api/mocks"
 	"github.com/companieshouse/insolvency-api/models"
@@ -256,7 +257,7 @@ func TestUnitHandleCreateStatementOfAffairs(t *testing.T) {
 		So(res.Body.String(), ShouldContainSubstring, "please supply only one attachment")
 	})
 
-	Convey("Attachment is not of type statement-of-affairs-director or liquidator", t, func() {
+	Convey("Attachment is not of type statement-of-affairs-director, liquidator or concurrence", t, func() {
 		mockService, _, rec := mock_dao.CreateTestObjects(t)
 		httpmock.Activate()
 
@@ -278,7 +279,7 @@ func TestUnitHandleCreateStatementOfAffairs(t *testing.T) {
 		res := serveHandleCreateStatementOfAffairs(body, mockService, helperService, true, rec)
 
 		So(res.Code, ShouldEqual, http.StatusBadRequest)
-		So(res.Body.String(), ShouldContainSubstring, "attachment is not a statement-of-affairs-director or statement-of-affairs-liquidator")
+		So(res.Body.String(), ShouldContainSubstring, "attachment is not a " + constants.StatementOfAffairsDirector.String() + ", " + constants.StatementOfAffairsLiquidator.String() + " or a " + constants.StatementOfConcurrence.String())
 	})
 
 	Convey("Generic error when adding statement of affairs resource to mongo", t, func() {

--- a/mocks/service_mock.go
+++ b/mocks/service_mock.go
@@ -100,17 +100,17 @@ func (mr *MockServiceMockRecorder) CreateAppointmentResource(transactionInterfac
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAppointmentResource", reflect.TypeOf((*MockService)(nil).CreateAppointmentResource), transactionInterface)
 }
  
-// UpdateInsolvencyPractitioners mocks base method
-func (m *MockService) UpdateInsolvencyPractitioners(practitionersResource models.InsolvencyResourceDao, transactionID string) (int, error)  {
-	ret := m.ctrl.Call(m, "UpdateInsolvencyPractitioners", practitionersResource, transactionID)
+// AddPractitionerToInsolvencyResource mocks base method
+func (m *MockService) AddPractitionerToInsolvencyResource(practitionerID string, practitionerLink string, transactionID string) (int, error)  {
+	ret := m.ctrl.Call(m, "AddPractitionerToInsolvencyResource", practitionerID, practitionerLink, transactionID)
 	ret0, _ := ret[0].(int)
 	ret1, _ := ret[1].(error)
-	return ret0, ret1 
+	return ret0, ret1
 }
 
-// UpdateInsolvencyPractitioners indicates an expected call of UpdateInsolvencyPractitioners
-func (mr *MockServiceMockRecorder) UpdateInsolvencyPractitioners(practitionersResource, transactionID interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateInsolvencyPractitioners", reflect.TypeOf((*MockService)(nil).UpdateInsolvencyPractitioners),practitionersResource, transactionID)
+// AddPractitionerToInsolvencyResource indicates an expected call of AddPractitionerToInsolvencyResource
+func (mr *MockServiceMockRecorder) AddPractitionerToInsolvencyResource(practitionerID, practitionerLink, transactionID interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddPractitionerToInsolvencyResource", reflect.TypeOf((*MockService)(nil).AddPractitionerToInsolvencyResource), practitionerID, practitionerLink, transactionID)
 }
 
 // GetPractitionersResource mocks base method

--- a/models/data_entities.go
+++ b/models/data_entities.go
@@ -7,19 +7,23 @@ type InsolvencyResourceDao struct {
 	ID            primitive.ObjectID `bson:"_id"`
 	TransactionID string             `bson:"transaction_id"`
 	Data          struct {
-		CompanyNumber      string                         `bson:"company_number"`
-		CaseType           string                         `bson:"case_type"`
-		CompanyName        string                         `bson:"company_name"`
-		Etag               string                         `bson:"etag"`
-		Kind               string                         `bson:"kind"`
-		Practitioners      string                         `bson:"practitioners,omitempty"`
-		Links              InsolvencyResourceLinksDao     `bson:"links,omitempty"`
-		Attachments        []AttachmentResourceDao        `bson:"attachments,omitempty"`
-		Resolution         *ResolutionResourceDao         `bson:"resolution,omitempty"`
-		StatementOfAffairs *StatementOfAffairsResourceDao `bson:"statement-of-affairs,omitempty"`
-		ProgressReport     *ProgressReportResourceDao     `bson:"progress-report,omitempty"`
+		CompanyNumber      string                              `bson:"company_number"`
+		CaseType           string                              `bson:"case_type"`
+		CompanyName        string                              `bson:"company_name"`
+		Etag               string                              `bson:"etag"`
+		Kind               string                              `bson:"kind"`
+		Practitioners      *InsolvencyResourcePractitionersDao `bson:"practitioners,omitempty"`
+		Links              InsolvencyResourceLinksDao          `bson:"links,omitempty"`
+		Attachments        []AttachmentResourceDao             `bson:"attachments,omitempty"`
+		Resolution         *ResolutionResourceDao              `bson:"resolution,omitempty"`
+		StatementOfAffairs *StatementOfAffairsResourceDao      `bson:"statement-of-affairs,omitempty"`
+		ProgressReport     *ProgressReportResourceDao          `bson:"progress-report,omitempty"`
 	}
 }
+
+// InsolvencyResourcePractitionersDao contains a map of links to the practitioner
+// resources associated with an insolvency resource, keyed by PractitionerID
+type InsolvencyResourcePractitionersDao map[string]string
 
 // InsolvencyResourceLinksDao contains the links for the insolvency resource
 type InsolvencyResourceLinksDao struct {

--- a/models/request_entities.go
+++ b/models/request_entities.go
@@ -2,7 +2,7 @@ package models
 
 // InsolvencyRequest is the model that should be sent to the insolvency API when creating a new request.
 type InsolvencyRequest struct {
-	CompanyNumber string `json:"company_number" validate:"required"`
+	CompanyNumber string `json:"company_number" validate:"required,alphanum"`
 	CompanyName   string `json:"company_name" validate:"required"`
 	CaseType      string `json:"case_type" validate:"required"`
 }

--- a/models/response_entities.go
+++ b/models/response_entities.go
@@ -55,11 +55,11 @@ type CreatedPractitionerLinksResource struct {
 
 // AppointedPractitionerResource contains the details of an appointed practitioner
 type AppointedPractitionerResource struct {
-	AppointedOn string                      `json:"appointed_on"`
-	MadeBy      string                      `json:"made_by"`
-	Links       AppointmentResourceLinksDao `json:"links"`
-	Etag        string                      `json:"etag"`
-	Kind        string                      `json:"kind"`
+	AppointedOn string                             `json:"appointed_on"`
+	MadeBy      string                             `json:"made_by"`
+	Links       AppointedPractitionerLinksResource `json:"links"`
+	Etag        string                             `json:"etag"`
+	Kind        string                             `json:"kind"`
 }
 
 // AppointedPractitionerLinksResource contains the links details for a practitioner appointment

--- a/service/insolvency_service_test.go
+++ b/service/insolvency_service_test.go
@@ -24,10 +24,10 @@ var req = httptest.NewRequest(http.MethodPut, "/test", nil)
 func createInsolvencyResource() *models.InsolvencyResourceDao {
 	_, practitionerResourceDao, appointmentResourceDao := generateInsolvencyPractitionerAppointmentResources()
 
-	jsonPractitionersDao := `{
+	insolvencyResourcePractitionersDao := models.InsolvencyResourcePractitionersDao{
 		"VM04221441": "/transactions/168570-809316-704268/insolvency/practitioners/VM04221441",
-		"VM04221442": "/transactions/168570-809316-704268/insolvency/practitioners/VM04221442"
-	}`
+		"VM04221442": "/transactions/168570-809316-704268/insolvency/practitioners/VM04221442",
+	}
 
 	appointmentResourceDao.Data.AppointedOn = "2021-07-07"
 	appointmentResourceDao.Data.MadeBy = "creditors"
@@ -58,7 +58,7 @@ func createInsolvencyResource() *models.InsolvencyResourceDao {
 	insolvencyResourceDao.Data.CompanyNumber = companyNumber
 	insolvencyResourceDao.Data.CompanyName = companyName
 	insolvencyResourceDao.Data.CaseType = "insolvency"
-	insolvencyResourceDao.Data.Practitioners = jsonPractitionersDao
+	insolvencyResourceDao.Data.Practitioners = &insolvencyResourcePractitionersDao
 	insolvencyResourceDao.Data.Attachments = []models.AttachmentResourceDao{
 		{
 			ID:     "id",
@@ -535,7 +535,7 @@ func TestUnitValidateInsolvencyDetails(t *testing.T) {
 
 				// Remove practitioner for SOA-L to prevent triggering another error
 				if attachment == constants.StatementOfAffairsLiquidator.String() {
-					insolvencyCase.Data.Practitioners = ""
+					insolvencyCase.Data.Practitioners = nil
 				}
 
 				validationErrors := ValidateInsolvencyDetails(*insolvencyCase, practitionerResourceDaos)

--- a/service/insolvency_service_test.go
+++ b/service/insolvency_service_test.go
@@ -306,24 +306,6 @@ func TestUnitValidateInsolvencyDetails(t *testing.T) {
 		So(validationErrors, ShouldHaveLength, 0)
 	})
 
-	Convey("error - attachment type is statement-of-concurrence and attachment type statement-of-affairs-director is not present", t, func() {
-		insolvencyCase := createInsolvencyResource()
-		// Set attachment type to "statement-of-concurrence"
-		insolvencyCase.Data.Attachments = append(insolvencyCase.Data.Attachments, models.AttachmentResourceDao{Type: "statement-of-concurrence"})
-		// Remove SOA director
-		insolvencyCase.Data.Attachments[1].Type = "type"
-		// Remove SOA
-		insolvencyCase.Data.StatementOfAffairs = nil
-
-		practitionerResourceDaos := append([]models.PractitionerResourceDao{}, models.PractitionerResourceDao{})
-
-		validationErrors := ValidateInsolvencyDetails(*insolvencyCase, practitionerResourceDaos)
-
-		So(validationErrors, ShouldHaveLength, 1)
-		So((*validationErrors)[0].Error, ShouldContainSubstring, fmt.Sprintf("error - attachment statement-of-concurrence must be accompanied by statement-of-affairs-director attachment for insolvency case with transaction id [%s]", insolvencyCase.TransactionID))
-		So((*validationErrors)[0].Location, ShouldContainSubstring, "statement of concurrence attachment type")
-	})
-
 	Convey("successful validation of statement-of-concurrence attachment - attachment type is statement-of-concurrence and statement-of-affairs-director are present", t, func() {
 		insolvencyCase := createInsolvencyResource()
 		insolvencyCase.Data.Resolution = nil
@@ -525,87 +507,97 @@ func TestUnitValidateInsolvencyDetails(t *testing.T) {
 		So(validationErrors, ShouldHaveLength, 0)
 	})
 
-	Convey("error - statement-of-affairs-director filed but no statement date exists in DB", t, func() {
+	// Loop through SOA attachment types to repeat test to convey the following:
+	// error - <attachment type> filed but no statement date/resource exists in DB
+	attachmentTypes := []string{constants.StatementOfAffairsDirector.String(), constants.StatementOfAffairsLiquidator.String(), constants.StatementOfConcurrence.String()}
+	contextList := []string{"date", "resource"}
+	for _, attachment := range attachmentTypes {
+		for _, contextItem := range contextList {
+			conveyTitle := "error - " + attachment + " filed but no statement " + contextItem + " exists in DB"
+			// Convey.. e.g. error - statement-of-affairs-director filed but no statement date exists in DB
+			Convey(conveyTitle, t, func() {
+				// Create insolvency case
+				insolvencyCase := createInsolvencyResource()
+				switch contextItem {
+				case "date":
+					// Remove the date value
+					insolvencyCase.Data.StatementOfAffairs = &models.StatementOfAffairsResourceDao{
+						StatementDate: "",
+					}
+				case "resource":
+					// Remove the SOA resource
+					insolvencyCase.Data.StatementOfAffairs = nil
+				}
 
-		// Create insolvency case and remove SOA date
-		insolvencyCase := createInsolvencyResource()
-		insolvencyCase.Data.StatementOfAffairs = &models.StatementOfAffairsResourceDao{
-			StatementDate: "",
+				// Change attachment type
+				insolvencyCase.Data.Attachments[1].Type = attachment
+				practitionerResourceDaos := append([]models.PractitionerResourceDao{})
+
+				// Remove practitioner for SOA-L to prevent triggering another error
+				if attachment == constants.StatementOfAffairsLiquidator.String() {
+					insolvencyCase.Data.Practitioners = ""
+				}
+
+				validationErrors := ValidateInsolvencyDetails(*insolvencyCase, practitionerResourceDaos)
+				So(validationErrors, ShouldHaveLength, 1)
+				So((*validationErrors)[0].Error, ShouldContainSubstring, fmt.Sprintf("error - a date of statement of affairs must be present as there is an attachment with a type of [%s], [%s], or a [%s] for insolvency case with transaction id [%s]", constants.StatementOfAffairsDirector.String(), constants.StatementOfConcurrence.String(), constants.StatementOfAffairsLiquidator.String(), insolvencyCase.TransactionID))
+				So((*validationErrors)[0].Location, ShouldContainSubstring, "statement-of-affairs")
+			})
 		}
-
-		practitionerResourceDaos := append([]models.PractitionerResourceDao{})
-		validationErrors := ValidateInsolvencyDetails(*insolvencyCase, practitionerResourceDaos)
-
-		So(validationErrors, ShouldHaveLength, 1)
-		So((*validationErrors)[0].Error, ShouldContainSubstring, fmt.Sprintf("error - a date of statement of affairs must be present as there is an attachment with type [%s] or [%s] for insolvency case with transaction id [%s]", constants.StatementOfAffairsDirector.String(), constants.StatementOfAffairsLiquidator.String(), insolvencyCase.TransactionID))
-		So((*validationErrors)[0].Location, ShouldContainSubstring, "statement-of-affairs")
-	})
-
-	Convey("error - statement-of-affairs-liquidator filed but no statement resource exists in DB", t, func() {
-
-		// Create insolvency case
-		insolvencyCase := createInsolvencyResource()
-
-		// Change attachment type to SOA-L
-		insolvencyCase.Data.Attachments[1].Type = "statement-of-affairs-liquidator"
-
-		// Make statement date an empty string
-		insolvencyCase.Data.StatementOfAffairs = &models.StatementOfAffairsResourceDao{
-			StatementDate: "",
-		}
-
-		validationErrors := ValidateInsolvencyDetails(*insolvencyCase, nil)
-
-		So(validationErrors, ShouldHaveLength, 1)
-		So((*validationErrors)[0].Error, ShouldContainSubstring, fmt.Sprintf("error - a date of statement of affairs must be present as there is an attachment with type [%s] or [%s] for insolvency case with transaction id [%s]", constants.StatementOfAffairsDirector.String(), constants.StatementOfAffairsLiquidator.String(), insolvencyCase.TransactionID))
-		So((*validationErrors)[0].Location, ShouldContainSubstring, "statement-of-affairs")
-	})
-
-	Convey("error - statement-of-affairs-director filed but no statement resource exists in DB", t, func() {
-
-		// Create insolvency case and remove SOA date
-		insolvencyCase := createInsolvencyResource()
-		insolvencyCase.Data.StatementOfAffairs = nil
-
-		practitionerResourceDaos := append([]models.PractitionerResourceDao{})
-
-		validationErrors := ValidateInsolvencyDetails(*insolvencyCase, practitionerResourceDaos)
-
-		So(validationErrors, ShouldHaveLength, 1)
-		So((*validationErrors)[0].Error, ShouldContainSubstring, fmt.Sprintf("error - a date of statement of affairs must be present as there is an attachment with type [%s] or [%s] for insolvency case with transaction id [%s]", constants.StatementOfAffairsDirector.String(), constants.StatementOfAffairsLiquidator.String(), insolvencyCase.TransactionID))
-		So((*validationErrors)[0].Location, ShouldContainSubstring, "statement-of-affairs")
-	})
-
-	Convey("error - statement-of-affairs-liquidator filed but no statement resource exists in DB", t, func() {
-
-		// Create insolvency case
-		insolvencyCase := createInsolvencyResource()
-
-		// Change attachment type to SOA-L
-		insolvencyCase.Data.Attachments[1].Type = "statement-of-affairs-liquidator"
-
-		// Remove statement resource
-		insolvencyCase.Data.StatementOfAffairs = nil
-
-		validationErrors := ValidateInsolvencyDetails(*insolvencyCase, nil)
-
-		So(validationErrors, ShouldHaveLength, 1)
-		So((*validationErrors)[0].Error, ShouldContainSubstring, fmt.Sprintf("error - a date of statement of affairs must be present as there is an attachment with type [%s] or [%s] for insolvency case with transaction id [%s]", constants.StatementOfAffairsDirector.String(), constants.StatementOfAffairsLiquidator.String(), insolvencyCase.TransactionID))
-		So((*validationErrors)[0].Location, ShouldContainSubstring, "statement-of-affairs")
-	})
+	}
 
 	Convey("error - statement resource exists in DB but no statement-of-affairs attachment filed", t, func() {
 
-		// Create insolvency case and remove SOA date
+		// Create insolvency case
 		insolvencyCase := createInsolvencyResource()
 		insolvencyCase.Data.Attachments[1].Type = "random"
 
 		practitionerResourceDaos := append([]models.PractitionerResourceDao{})
+
 		validationErrors := ValidateInsolvencyDetails(*insolvencyCase, practitionerResourceDaos)
 
 		So(validationErrors, ShouldHaveLength, 1)
-		So((*validationErrors)[0].Error, ShouldContainSubstring, fmt.Sprintf("error - an attachment of type [%s] or [%s] must be present as there is a date of statement of affairs present for insolvency case with transaction id [%s]", constants.StatementOfAffairsDirector.String(), constants.StatementOfAffairsLiquidator.String(), insolvencyCase.TransactionID))
+		So((*validationErrors)[0].Error, ShouldContainSubstring, fmt.Sprintf("error - an attachment of type [%s], [%s], or a [%s] must be present as there is a date of statement of affairs present for insolvency case with transaction id [%s]", constants.StatementOfAffairsDirector.String(), constants.StatementOfConcurrence.String(), constants.StatementOfAffairsLiquidator.String(), insolvencyCase.TransactionID))
 		So((*validationErrors)[0].Location, ShouldContainSubstring, "statement-of-affairs")
+	})
+
+	Convey("error - attachment type is statement-of-concurrence and practitioner object empty", t, func() {
+
+		// Create insolvency case
+		insolvencyCase := createInsolvencyResource()
+
+		// Replace statement-of-affairs-director attachment type to statement-of-concurrence for the 2nd attachment
+		insolvencyCase.Data.Attachments[0].Type = "type"
+		insolvencyCase.Data.Attachments[1].Type = "statement-of-concurrence"
+		insolvencyCase.Data.Attachments[2].Type = "type2"
+
+		// Remove the resolution and progress report details
+		insolvencyCase.Data.Resolution = nil
+		insolvencyCase.Data.ProgressReport = nil
+
+		validationErrors := ValidateInsolvencyDetails(*insolvencyCase, nil)
+		So(validationErrors, ShouldHaveLength, 2)
+		So((*validationErrors)[0].Error, ShouldContainSubstring, fmt.Sprintf("error - attachment type requires that at least one practitioner must be present for insolvency case with transaction id [%s]", insolvencyCase.TransactionID))
+		So((*validationErrors)[1].Error, ShouldContainSubstring, "error - if no practitioners are present then an attachment of the type resolution must be present")
+	})
+
+	Convey("successful validation of statement-of-concurrence - attachment type is statement-of-concurrence and at least one practitioner present", t, func() {
+		insolvencyCase := createInsolvencyResource()
+		_, practitionerResourceDao, appointmentResourceDao := generateInsolvencyPractitionerAppointmentResources()
+		practitionerResourceDao.Data.Appointment = &appointmentResourceDao
+
+		// Replace statement-of-affairs-director attachment type to statement-of-concurrence for the 2nd attachment
+		insolvencyCase.Data.Attachments[0].Type = "type"
+		insolvencyCase.Data.Attachments[1].Type = "statement-of-concurrence"
+		insolvencyCase.Data.Attachments[2].Type = "type2"
+
+		// Remove the resolution and progress report details
+		insolvencyCase.Data.Resolution = nil
+		insolvencyCase.Data.ProgressReport = nil
+
+		practitionerResourceDaos := []models.PractitionerResourceDao{practitionerResourceDao}
+		validationErrors := ValidateInsolvencyDetails(*insolvencyCase, practitionerResourceDaos)
+		So(validationErrors, ShouldHaveLength, 0)
 	})
 
 	Convey("error - practitioner appointment is before date of resolution", t, func() {
@@ -709,22 +701,31 @@ func TestUnitValidateInsolvencyDetails(t *testing.T) {
 			So((*validationErrors)[0].Error, ShouldContainSubstring, "invalid resolution date")
 		})
 
-		Convey("Statement date before resolution date", func() {
+		Convey("Statement date is after the resolution date", func() {
 			insolvencyCase := createInsolvencyResource()
-			insolvencyCase.Data.StatementOfAffairs.StatementDate = "2021-07-20"
-			insolvencyCase.Data.Resolution.DateOfResolution = "2021-07-21"
+			insolvencyCase.Data.StatementOfAffairs.StatementDate = "2021-07-26"
+			insolvencyCase.Data.Resolution.DateOfResolution = "2021-07-25"
 
 			validationErrors := ValidateInsolvencyDetails(*insolvencyCase, nil)
-			So((*validationErrors)[0].Error, ShouldContainSubstring, "error - statement of affairs date must not be before resolution date")
+			So((*validationErrors)[0].Error, ShouldContainSubstring, "error - statement of affairs date ["+insolvencyCase.Data.StatementOfAffairs.StatementDate+"] must not be after the resolution date"+" ["+insolvencyCase.Data.Resolution.DateOfResolution+"]")
 		})
 
-		Convey("Statement date > 7 days after resolution date", func() {
+		Convey("Statement date more than 14 days prior to the resolution date", func() {
 			insolvencyCase := createInsolvencyResource()
-			insolvencyCase.Data.StatementOfAffairs.StatementDate = "2021-07-29"
-			insolvencyCase.Data.Resolution.DateOfResolution = "2021-07-21"
+			insolvencyCase.Data.StatementOfAffairs.StatementDate = "2021-07-10"
+			insolvencyCase.Data.Resolution.DateOfResolution = "2021-07-25"
 
 			validationErrors := ValidateInsolvencyDetails(*insolvencyCase, nil)
-			So((*validationErrors)[0].Error, ShouldContainSubstring, "error - statement of affairs date must be within 7 days of resolution date")
+			So((*validationErrors)[0].Error, ShouldContainSubstring, "error - statement of affairs date ["+insolvencyCase.Data.StatementOfAffairs.StatementDate+"] must not be more than 14 days prior to the resolution date"+" ["+insolvencyCase.Data.Resolution.DateOfResolution+"]")
+		})
+
+		Convey("Statement date is 14 days prior to the resolution date", func() {
+			insolvencyCase := createInsolvencyResource()
+			insolvencyCase.Data.StatementOfAffairs.StatementDate = "2021-07-11"
+			insolvencyCase.Data.Resolution.DateOfResolution = "2021-07-25"
+
+			validationErrors := ValidateInsolvencyDetails(*insolvencyCase, nil)
+			So(validationErrors, ShouldHaveLength, 0)
 		})
 
 	})

--- a/transformers/insolvency_resource.go
+++ b/transformers/insolvency_resource.go
@@ -88,9 +88,11 @@ func PractitionerResourceDaosToPractitionerFilingsResponse(practitionerResourceD
 			appointedPractitionerResource = models.AppointedPractitionerResource{
 				AppointedOn: practitioner.Data.Appointment.Data.AppointedOn,
 				MadeBy:      practitioner.Data.Appointment.Data.MadeBy,
-				Links:       practitioner.Data.Appointment.Data.Links,
-				Etag:        practitioner.Data.Appointment.Data.Etag,
-				Kind:        practitioner.Data.Appointment.Data.Kind,
+				Links: models.AppointedPractitionerLinksResource{
+					Self: practitioner.Data.Appointment.Data.Links.Self,
+				},
+				Etag: practitioner.Data.Appointment.Data.Etag,
+				Kind: practitioner.Data.Appointment.Data.Kind,
 			}
 
 			practitionerResponse.Appointment = &appointedPractitionerResource
@@ -116,8 +118,9 @@ func AppointmentResourceDaoToAppointedResponse(model *models.AppointmentResource
 	return &models.AppointedPractitionerResource{
 		AppointedOn: model.Data.AppointedOn,
 		MadeBy:      model.Data.MadeBy,
-		Links:       model.Data.Links,
-	}
+		Links: models.AppointedPractitionerLinksResource{
+			Self: model.Data.Links.Self,
+		}}
 }
 
 // AttachmentResourceDaoToResponse transforms an attachment resource dao and file attachment details into a response entity

--- a/transformers/practitioner_resource.go
+++ b/transformers/practitioner_resource.go
@@ -109,8 +109,10 @@ func PractitionerAppointmentDaoToResponse(appointment *models.AppointmentResourc
 	return models.AppointedPractitionerResource{
 		AppointedOn: appointment.Data.AppointedOn,
 		MadeBy:      appointment.Data.MadeBy,
-		Links:       appointment.Data.Links,
-		Etag:        appointment.Data.Etag,
-		Kind:        appointment.Data.Kind,
+		Links: models.AppointedPractitionerLinksResource{
+			Self: appointment.Data.Links.Self,
+		},
+		Etag: appointment.Data.Etag,
+		Kind: appointment.Data.Kind,
 	}
 }

--- a/utils/converter.go
+++ b/utils/converter.go
@@ -1,36 +1,8 @@
 package utils
 
 import (
-	"encoding/json"
 	"strings"
 )
-
-// ConvertStringToMapObjectAndStringList is a helper function to convert string to map object
-func ConvertStringToMapObjectAndStringList(mapString string) (map[string]string, []string, error) {
-	var mapResource map[string]string
-	var stringPractitionerIdsArray []string
-
-	err := json.Unmarshal([]byte(mapString), &mapResource)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	for key := range mapResource {
-		stringPractitionerIdsArray = append(stringPractitionerIdsArray, key)
-	}
-
-	return mapResource, stringPractitionerIdsArray, nil
-}
-
-// ConvertMapToString is a helper function to convert map[string]string to string
-func ConvertMapToString(mapString map[string]string) (string, error) {
-	stringPractitionerLinks, err := json.Marshal(mapString)
-	if err != nil {
-		return "", err
-	}
-
-	return string(stringPractitionerLinks), nil
-}
 
 // CheckStringContainsElement is a helper function to check if an element is in string array
 func CheckStringContainsElement(stringItem string, splitChar string, find string) bool {
@@ -44,12 +16,12 @@ func CheckStringContainsElement(stringItem string, splitChar string, find string
 	return false
 }
 
-// ConvertMapToStringArray is a helper function to convert map[string]string to string array
-func ConvertMapToStringArray(mapString map[string]string) []string {
-	var practitionerIds []string
-	for practitionerId := range mapString {
-		practitionerIds = append(practitionerIds, practitionerId)
+// GetMapKeysAsStringSlice returns a string map's keys as a slice of strings
+func GetMapKeysAsStringSlice(stringMap map[string]string) []string {
+	var keys []string
+	for k := range stringMap {
+		keys = append(keys, k)
 	}
 
-	return practitionerIds
+	return keys
 }

--- a/utils/converter_test.go
+++ b/utils/converter_test.go
@@ -9,51 +9,30 @@ import (
 func TestUnitConverter(t *testing.T) {
 	jsonPractitionersDao := `{"VM04221441":"/transactions/168570-809316-704268/insolvency/practitioners/VM04221441"}`
 
-	stringMapArray := map[string]string{"VM04221441": "/transactions/168570-809316-704268/insolvency/practitioners/VM04221441"}
+	stringMap := map[string]string{"VM04221441": "/transactions/168570-809316-704268/insolvency/practitioners/VM04221441"}
 
-	Convey("ConvertStringToMapObjectAndStringList returns required objects", t, func() {
+	Convey("GetMapKeysAsStringSlice returns required objects", t, func() {
 
-		mapObject, arrayString, err := ConvertStringToMapObjectAndStringList(jsonPractitionersDao)
+		stringSlice := GetMapKeysAsStringSlice(stringMap)
 
-		So(mapObject, ShouldNotBeNil)
-		So(arrayString, ShouldNotBeNil)
-		So(len(arrayString), ShouldEqual, 1)
-		So(err, ShouldBeNil)
-	})
-
-	Convey("ConvertMapToString returns required objects", t, func() {
-
-		arrayString, err := ConvertMapToString(stringMapArray)
-
-		So(arrayString, ShouldNotBeNil)
-		So(arrayString, ShouldEqual, jsonPractitionersDao)
-		So(err, ShouldBeNil)
-	})
-
-	Convey("ConvertMapToStringArray returns required objects", t, func() {
-
-		arrayString := ConvertMapToStringArray(stringMapArray)
-
-		So(arrayString, ShouldNotBeNil)
-		So(arrayString, ShouldResemble, []string{"VM04221441"})
+		So(stringSlice, ShouldNotBeNil)
+		So(stringSlice, ShouldResemble, []string{"VM04221441"})
 
 	})
 
 	Convey("CheckStringContainsElement returns true when required element is found", t, func() {
 
-		arrayString := CheckStringContainsElement(jsonPractitionersDao, "/", "168570-809316-704268")
+		booleanResult := CheckStringContainsElement(jsonPractitionersDao, "/", "168570-809316-704268")
 
-		So(arrayString, ShouldNotBeNil)
-		So(arrayString, ShouldBeTrue)
+		So(booleanResult, ShouldBeTrue)
 
 	})
 
-	Convey("CheckStringContainsElement returns false when required element is found", t, func() {
+	Convey("CheckStringContainsElement returns false when required element is not found", t, func() {
 
-		arrayString := CheckStringContainsElement(jsonPractitionersDao, "/", "168570-809316-7042622")
+		booleanResult := CheckStringContainsElement(jsonPractitionersDao, "/", "168570-809316-7042622")
 
-		So(arrayString, ShouldNotBeNil)
-		So(arrayString, ShouldBeFalse)
+		So(booleanResult, ShouldBeFalse)
 
 	})
 


### PR DESCRIPTION
- main change is to store insolvency resource's practitioner links as
map rather than string in DB & when passing in code as DAO
- took out a couple of no-longer-needed helper functions to do with
string<->map conversion
- also adjusted practitioner's appointment link format (to simple
string, as single value so no need to key by practitioner ID within
individual practitioner resource)
- also adjusted appointment resource response object to correct
Self/self json lowercase issue in json response for appointment resource
links section
- increased test coverage a little & cleared out some unused data
structures in mongo_driver_test.go
- merged from the main branch before starting this work