### PR TITLE
reverted to using two separate error messages for attachment validation

### DIFF
--- a/handlers/soa_resource_test.go
+++ b/handlers/soa_resource_test.go
@@ -255,7 +255,7 @@ func TestUnitHandleCreateStatementOfAffairs(t *testing.T) {
 		res := serveHandleCreateStatementOfAffairs(body, mockService, helperService, true, rec)
 
 		So(res.Code, ShouldEqual, http.StatusBadRequest)
-		So(res.Body.String(), ShouldContainSubstring, "please supply a maximum of two attachments")
+		So(res.Body.String(), ShouldContainSubstring, "please supply at least one attachment")
 	})
 
 	Convey("Attachment is not of type statement-of-affairs-director, liquidator or concurrence", t, func() {

--- a/service/soa_service.go
+++ b/service/soa_service.go
@@ -22,9 +22,15 @@ func ValidateStatementDetails(svc dao.Service, statementDao *models.StatementOfA
 	}
 
 	// Check that the attachment has been submitted correctly
-	if len(statementDao.Attachments) == 0 || len(statementDao.Attachments) > 2 {
+	if len(statementDao.Attachments) == 0 {
+		errs = append(errs, "please supply at least one attachment")
+	}
+	if len(statementDao.Attachments) > 2 {
 		errs = append(errs, "please supply a maximum of two attachments")
 	}
+	//if len(statementDao.Attachments) == 0 || len(statementDao.Attachments) > 2 {
+	//	errs = append(errs, "please supply a maximum of two attachments")
+	//}
 
 	// Check if statement date supplied is in the future or before company was incorporated
 	insolvencyResource, err := svc.GetInsolvencyResource(transactionID)

--- a/service/soa_service.go
+++ b/service/soa_service.go
@@ -28,9 +28,6 @@ func ValidateStatementDetails(svc dao.Service, statementDao *models.StatementOfA
 	if len(statementDao.Attachments) > 2 {
 		errs = append(errs, "please supply a maximum of two attachments")
 	}
-	//if len(statementDao.Attachments) == 0 || len(statementDao.Attachments) > 2 {
-	//	errs = append(errs, "please supply a maximum of two attachments")
-	//}
 
 	// Check if statement date supplied is in the future or before company was incorporated
 	insolvencyResource, err := svc.GetInsolvencyResource(transactionID)

--- a/service/soa_service_test.go
+++ b/service/soa_service_test.go
@@ -36,7 +36,7 @@ func TestUnitIsValidStatementDate(t *testing.T) {
 
 		validationErr, err := ValidateStatementDetails(mockService, &statement, transactionID, req)
 
-		So(validationErr, ShouldContainSubstring, "please supply a maximum of two attachments")
+		So(validationErr, ShouldContainSubstring, "please supply at least one attachment")
 		So(err, ShouldBeNil)
 	})
 


### PR DESCRIPTION
It's been agreed between dev and test that two separate error messages fits better.